### PR TITLE
ci: skip signing for maven local preflight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,6 @@ jobs:
           java-version: '21'
       - uses: gradle/actions/setup-gradle@v6
       - name: Publish Preflight
-        run: ./gradlew publishToMavenLocal --stacktrace
+        run: ./gradlew publishToMavenLocal -PsignAllPublications=false --stacktrace
       - name: Published Consumer Smoke Check
         run: bash tools/agent/check-published-consumer-smoke.sh


### PR DESCRIPTION
Fixes signing issues in CI by passing -PsignAllPublications=false to publishToMavenLocal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD build configuration to adjust publishing settings during preflight checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->