### PR TITLE
Bootstrap hooks and agent gates with modern Bash

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(git rev-parse --show-toplevel)"
+source "$ROOT_DIR/tools/agent/modern-bash.sh"
+ensure_modern_bash "$0" "$@"
 cd "$ROOT_DIR"
 
 echo "[pre-commit] Running advisory fast quality gate..."

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(git rev-parse --show-toplevel)"
+source "$ROOT_DIR/tools/agent/modern-bash.sh"
+ensure_modern_bash "$0" "$@"
 cd "$ROOT_DIR"
 
 echo "[pre-push] Running advisory strict quality gate..."

--- a/tools/agent/changed-modules.sh
+++ b/tools/agent/changed-modules.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT_DIR/tools/agent/modern-bash.sh"
+ensure_modern_bash "$0" "$@"
 cd "$ROOT_DIR"
 
 scope="changed"

--- a/tools/agent/context-pack.sh
+++ b/tools/agent/context-pack.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT_DIR/tools/agent/modern-bash.sh"
+ensure_modern_bash "$0" "$@"
 cd "$ROOT_DIR"
 
 task=""

--- a/tools/agent/docs-trace-check.sh
+++ b/tools/agent/docs-trace-check.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT_DIR/tools/agent/modern-bash.sh"
+ensure_modern_bash "$0" "$@"
 cd "$ROOT_DIR"
 
 changed_files_path=""

--- a/tools/agent/mermaid-trace-check.sh
+++ b/tools/agent/mermaid-trace-check.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT_DIR/tools/agent/modern-bash.sh"
+ensure_modern_bash "$0" "$@"
 cd "$ROOT_DIR"
 
 changed_files_path=""

--- a/tools/agent/modern-bash.sh
+++ b/tools/agent/modern-bash.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ensure_modern_bash() {
+    local script_path="$1"
+    shift || true
+
+    if [[ "$script_path" != /* ]]; then
+        script_path="$(cd "$(dirname "$script_path")" && pwd)/$(basename "$script_path")"
+    fi
+
+    if [[ "${BASH_VERSINFO[0]:-0}" -ge 4 ]]; then
+        export AGENT_BASH_BIN="${AGENT_BASH_BIN:-$BASH}"
+        if [[ "$AGENT_BASH_BIN" != */* ]]; then
+            AGENT_BASH_BIN="$(command -v "$AGENT_BASH_BIN" || echo "$AGENT_BASH_BIN")"
+            export AGENT_BASH_BIN
+        fi
+        if [[ "$AGENT_BASH_BIN" == */* ]]; then
+            export PATH="$(dirname "$AGENT_BASH_BIN"):$PATH"
+        fi
+        return 0
+    fi
+
+    local candidates=(
+        "/opt/homebrew/bin/bash"
+        "/usr/local/bin/bash"
+    )
+
+    local candidate
+    for candidate in "${candidates[@]}"; do
+        [[ -x "$candidate" ]] || continue
+        if "$candidate" -c '[[ "${BASH_VERSINFO[0]:-0}" -ge 4 ]]'; then
+            export AGENT_BASH_BIN="$candidate"
+            export PATH="$(dirname "$candidate"):$PATH"
+            exec "$candidate" "$script_path" "$@"
+        fi
+    done
+
+    cat >&2 <<'EOF'
+ERROR: Bash 4+ is required for tools/agent scripts.
+Install a modern Bash (for example via Homebrew) and rerun:
+  brew install bash
+EOF
+    exit 1
+}

--- a/tools/agent/progress-report.sh
+++ b/tools/agent/progress-report.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT_DIR/tools/agent/modern-bash.sh"
+ensure_modern_bash "$0" "$@"
 cd "$ROOT_DIR"
 
 format="human"

--- a/tools/agent/quality-gate.sh
+++ b/tools/agent/quality-gate.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT_DIR/tools/agent/modern-bash.sh"
+ensure_modern_bash "$0" "$@"
 cd "$ROOT_DIR"
 
 mode="fast"

--- a/tools/agent/spec-trace-check.sh
+++ b/tools/agent/spec-trace-check.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT_DIR/tools/agent/modern-bash.sh"
+ensure_modern_bash "$0" "$@"
 cd "$ROOT_DIR"
 
 changed_files_path=""

--- a/tools/agent/status-trace-check.sh
+++ b/tools/agent/status-trace-check.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT_DIR/tools/agent/modern-bash.sh"
+ensure_modern_bash "$0" "$@"
 cd "$ROOT_DIR"
 
 changed_files_path=""

--- a/tools/agent/verify-harness-sync.sh
+++ b/tools/agent/verify-harness-sync.sh
@@ -26,6 +26,7 @@ required_files=(
   ".gemini/workflows/fast-pr-check.md"
   "tools/agent/quality-gate.sh"
   "tools/agent/check-published-consumer-smoke.sh"
+  "tools/agent/modern-bash.sh"
   "tools/agent/changed-modules.sh"
   "tools/agent/spec-trace-check.sh"
   "tools/agent/context-pack.sh"
@@ -64,8 +65,18 @@ if ! contains_pattern "--mode fast --scope changed --block false" .githooks/pre-
   exit 1
 fi
 
+if ! contains_pattern "modern-bash.sh" .githooks/pre-commit; then
+  echo "pre-commit hook is missing modern bash bootstrap" >&2
+  exit 1
+fi
+
 if ! contains_pattern "--mode strict --scope changed --block false" .githooks/pre-push; then
   echo "pre-push hook is out of policy" >&2
+  exit 1
+fi
+
+if ! contains_pattern "modern-bash.sh" .githooks/pre-push; then
+  echo "pre-push hook is missing modern bash bootstrap" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- add a shared modern Bash bootstrap helper for agent tooling
- make hooks and Bash-4+ agent scripts re-exec under Homebrew Bash when invoked from macOS `/bin/bash`
- extend harness sync checks so hook bootstrap cannot drift

## Why
macOS system Bash (3.2) lacks features used by gate scripts (`mapfile`, associative arrays), which caused advisory hook noise and degraded local gate behavior. This keeps behavior deterministic and explicit.

## Validation
- `/bin/bash tools/agent/quality-gate.sh --mode fast --scope changed --block false`
- `/bin/bash tools/agent/quality-gate.sh --mode strict --scope changed --block false`
- `/bin/bash tools/agent/verify-harness-sync.sh`
- `/bin/bash .githooks/pre-commit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Bash 4+ compatibility validation to development scripts and git hooks, ensuring consistent runtime requirements and providing clear guidance for users with older Bash versions to upgrade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->