### PR TITLE
samples: policy boundary + visibility cleanup (PR1)

### DIFF
--- a/build-logic/src/main/kotlin/webauthn.kotlin.multiplatform.gradle.kts
+++ b/build-logic/src/main/kotlin/webauthn.kotlin.multiplatform.gradle.kts
@@ -4,7 +4,9 @@ plugins {
 }
 
 kotlin {
-    explicitApi()
+    if (!project.path.startsWith(":samples:")) {
+        explicitApi()
+    }
 
     jvmToolchain(21)
 

--- a/docs/ai/CLIENT_SAMPLE_REWORK_EXECUTION_MAP.md
+++ b/docs/ai/CLIENT_SAMPLE_REWORK_EXECUTION_MAP.md
@@ -21,7 +21,7 @@ Each PR below should target `client-sample-rework-dev`.
 
 | PR | Branch | Status | Scope | Exit Criteria |
 | --- | --- | --- | --- | --- |
-| 1 | `client-sample-rework-pr1-policy-visibility` | In Progress | Sample policy boundary + visibility cleanup (`explicitApi` exclusion for samples, remove unnecessary `public`) | Sample modules compile with preserved host entrypoints and no accidental public-surface changes. |
+| 1 | `client-sample-rework-pr1-policy-visibility` | Completed | Sample policy boundary + visibility cleanup (`explicitApi` exclusion for samples, remove unnecessary `public`) | Sample modules compile with preserved host entrypoints and no accidental public-surface changes. |
 | 2 | `client-sample-rework-pr2-foundation` | Planned | Compose sample architecture skeleton (MVVM+UDF), typed routes, Navigation 3 setup, Koin graph, orchestration split out of monolithic `App()` | Compose sample compiles for Android and iOS simulator targets with new architecture wiring in place and no feature regressions. |
 | 3 | `client-sample-rework-pr3-auth-session` | Planned | Real login flow with `Auth` and `LoggedIn` screens, local session model, local logout behavior | Register/sign-in/logout transitions are deterministic in ViewModel tests and manual smoke checks. |
 | 4 | `client-sample-rework-pr4-debug-structure` | Planned | Hidden debug logs in bottom sheet via secret trigger, composable file-structure discipline, state-driven renderers | Debug sheet remains hidden by default, opens via secret trigger, and composable boundaries follow one reusable `internal` composable per file. |

--- a/samples/android-passkey/src/main/kotlin/dev/webauthn/samples/android/MainActivity.kt
+++ b/samples/android-passkey/src/main/kotlin/dev/webauthn/samples/android/MainActivity.kt
@@ -3,7 +3,7 @@ package dev.webauthn.samples.android
 import android.app.Activity
 import android.os.Bundle
 
-public class MainActivity : Activity() {
+class MainActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
     }

--- a/samples/compose-passkey-android/src/main/kotlin/dev/webauthn/samples/composepasskey/android/MainActivity.kt
+++ b/samples/compose-passkey-android/src/main/kotlin/dev/webauthn/samples/composepasskey/android/MainActivity.kt
@@ -8,7 +8,7 @@ import dev.webauthn.samples.composepasskey.App
 
 private const val TAG: String = "PasskeyDemo"
 
-public class MainActivity : ComponentActivity() {
+class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         Log.i(TAG, "MainActivity.onCreate")

--- a/samples/compose-passkey/src/androidMain/kotlin/dev/webauthn/samples/composepasskey/PlatformProviders.android.kt
+++ b/samples/compose-passkey/src/androidMain/kotlin/dev/webauthn/samples/composepasskey/PlatformProviders.android.kt
@@ -12,7 +12,7 @@ import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 
 @Composable
-public actual fun rememberPlatformHttpClient(onLogLine: (String) -> Unit): HttpClient {
+actual fun rememberPlatformHttpClient(onLogLine: (String) -> Unit): HttpClient {
     return remember(onLogLine) {
         HttpClient(OkHttp) {
             install(ContentNegotiation) {
@@ -35,4 +35,4 @@ public actual fun rememberPlatformHttpClient(onLogLine: (String) -> Unit): HttpC
     }
 }
 
-public actual fun platformRuntimeHint(): String? = null
+actual fun platformRuntimeHint(): String? = null

--- a/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/App.kt
+++ b/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/App.kt
@@ -40,7 +40,7 @@ import dev.webauthn.samples.composepasskey.ui.theme.EditorialTypography
 import kotlinx.coroutines.launch
 
 @Composable
-public fun App() {
+fun App() {
     val scope = rememberCoroutineScope()
     val debugLogs = remember { DebugLogStore() }
     val httpLogSink: (String) -> Unit = remember(scope, debugLogs) {

--- a/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/PasskeyDemoFlow.kt
+++ b/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/PasskeyDemoFlow.kt
@@ -8,18 +8,18 @@ import dev.webauthn.samples.composepasskey.model.DebugLogLevel
 import dev.webauthn.samples.composepasskey.model.PasskeyDemoStatus
 import dev.webauthn.samples.composepasskey.model.StatusTone
 
-public data class PasskeyDemoConfig(
-    public val endpointBase: String = PasskeyDemoBuildConfig.ENDPOINT_BASE,
-    public val rpId: String = resolveDefaultRpId(
+data class PasskeyDemoConfig(
+    val endpointBase: String = PasskeyDemoBuildConfig.ENDPOINT_BASE,
+    val rpId: String = resolveDefaultRpId(
         endpointBase = endpointBase,
         configuredRpId = PasskeyDemoBuildConfig.RP_ID,
     ),
-    public val origin: String = resolveDefaultOrigin(
+    val origin: String = resolveDefaultOrigin(
         rpId = rpId,
         configuredOrigin = PasskeyDemoBuildConfig.ORIGIN,
     ),
-    public val userHandle: String = PasskeyDemoBuildConfig.USER_ID,
-    public val userName: String = PasskeyDemoBuildConfig.USER_NAME,
+    val userHandle: String = PasskeyDemoBuildConfig.USER_ID,
+    val userName: String = PasskeyDemoBuildConfig.USER_NAME,
 )
 
 internal fun areCeremonyActionsEnabled(uiState: PasskeyControllerState): Boolean {
@@ -106,7 +106,7 @@ internal fun controllerTransitionLog(
     return null
 }
 
-private enum class PasskeyDemoErrorCategory(public val label: String) {
+private enum class PasskeyDemoErrorCategory(val label: String) {
     INVALID_OPTIONS("Invalid Options"),
     USER_CANCELLED("User Cancelled"),
     PLATFORM("Platform"),

--- a/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/PlatformProviders.kt
+++ b/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/PlatformProviders.kt
@@ -4,6 +4,6 @@ import androidx.compose.runtime.Composable
 import io.ktor.client.HttpClient
 
 @Composable
-public expect fun rememberPlatformHttpClient(onLogLine: (String) -> Unit): HttpClient
+expect fun rememberPlatformHttpClient(onLogLine: (String) -> Unit): HttpClient
 
-public expect fun platformRuntimeHint(): String?
+expect fun platformRuntimeHint(): String?

--- a/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/PrfCryptoDemo.kt
+++ b/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/PrfCryptoDemo.kt
@@ -20,7 +20,7 @@ private const val PRF_SALT_LENGTH_BYTES: Int = 32
 private const val SAMPLE_PRF_CONTEXT: String = "samples.compose-passkey.prf.v1"
 private const val SAMPLE_ASSOCIATED_DATA: String = "samples-compose-passkey"
 
-public sealed interface PrfCryptoDemoSessionState {
+sealed interface PrfCryptoDemoSessionState {
     data object NoSession : PrfCryptoDemoSessionState
 
     data object SessionReady : PrfCryptoDemoSessionState

--- a/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/model/DemoModels.kt
+++ b/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/model/DemoModels.kt
@@ -2,7 +2,7 @@ package dev.webauthn.samples.composepasskey.model
 
 import kotlin.time.Instant
 
-public enum class StatusTone {
+enum class StatusTone {
     IDLE,
     WORKING,
     SUCCESS,
@@ -10,22 +10,22 @@ public enum class StatusTone {
     ERROR,
 }
 
-public enum class DebugLogLevel {
+enum class DebugLogLevel {
     DEBUG,
     INFO,
     WARN,
     ERROR,
 }
 
-public data class DebugLogEntry(
-    public val id: Long,
-    public val timestamp: Instant,
-    public val level: DebugLogLevel,
-    public val source: String,
-    public val message: String,
+data class DebugLogEntry(
+    val id: Long,
+    val timestamp: Instant,
+    val level: DebugLogLevel,
+    val source: String,
+    val message: String,
 )
 
-public data class PasskeyDemoStatus(
+data class PasskeyDemoStatus(
     val tone: StatusTone,
     val headline: String,
     val detail: String? = null,

--- a/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/components/ActionsCard.kt
+++ b/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/components/ActionsCard.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
 @Composable
-public fun ActionsCard(
+fun ActionsCard(
     actionsEnabled: Boolean,
     onRegister: () -> Unit,
     onSignIn: () -> Unit,

--- a/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/components/CapabilitiesCard.kt
+++ b/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/components/CapabilitiesCard.kt
@@ -29,7 +29,7 @@ import dev.webauthn.client.PasskeyCapability
 import dev.webauthn.model.WebAuthnExtension
 
 @Composable
-public fun CapabilitiesCard(
+fun CapabilitiesCard(
     capabilities: PasskeyCapabilities,
 ) {
     val prfCapability = remember { PasskeyCapability.Extension(WebAuthnExtension.Prf) }

--- a/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/components/DebugLogCard.kt
+++ b/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/components/DebugLogCard.kt
@@ -26,7 +26,7 @@ import dev.webauthn.samples.composepasskey.model.DebugLogEntry
 import dev.webauthn.samples.composepasskey.model.DebugLogLevel
 
 @Composable
-public fun DebugLogCard(entries: List<DebugLogEntry>) {
+fun DebugLogCard(entries: List<DebugLogEntry>) {
     ElevatedCard(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.elevatedCardColors(containerColor = MaterialTheme.colorScheme.surface),

--- a/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/components/Header.kt
+++ b/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/components/Header.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.unit.dp
 import dev.webauthn.samples.composepasskey.model.PasskeyDemoStatus
 
 @Composable
-public fun Header(status: PasskeyDemoStatus) {
+fun Header(status: PasskeyDemoStatus) {
     ElevatedCard(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.elevatedCardColors(containerColor = MaterialTheme.colorScheme.surface),

--- a/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/components/PrfCryptoCard.kt
+++ b/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/components/PrfCryptoCard.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.unit.dp
 import dev.webauthn.samples.composepasskey.PrfCryptoDemoSessionState
 
 @Composable
-public fun PrfCryptoCard(
+fun PrfCryptoCard(
     modifier: Modifier = Modifier,
     supportsPrf: Boolean,
     actionsEnabled: Boolean,

--- a/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/theme/Theme.kt
+++ b/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/theme/Theme.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
-public val EditorialPalette: androidx.compose.material3.ColorScheme = lightColorScheme(
+val EditorialPalette: androidx.compose.material3.ColorScheme = lightColorScheme(
     primary = Color(0xFF1E4A68),
     onPrimary = Color(0xFFFFFFFF),
     secondary = Color(0xFF6D8A56),
@@ -24,7 +24,7 @@ public val EditorialPalette: androidx.compose.material3.ColorScheme = lightColor
     onError = Color(0xFFFFFFFF),
 )
 
-public val EditorialTypography: Typography = Typography().run {
+val EditorialTypography: Typography = Typography().run {
     copy(
         headlineLarge = headlineLarge.copy(
             fontFamily = FontFamily.Serif,

--- a/samples/compose-passkey/src/iosMain/kotlin/dev/webauthn/samples/composepasskey/MainViewController.kt
+++ b/samples/compose-passkey/src/iosMain/kotlin/dev/webauthn/samples/composepasskey/MainViewController.kt
@@ -2,7 +2,7 @@ package dev.webauthn.samples.composepasskey
 
 import androidx.compose.ui.window.ComposeUIViewController
 
-public fun MainViewController() = ComposeUIViewController(
+fun MainViewController() = ComposeUIViewController(
     configure = {
         // Keep the sample app runnable even when host apps use generated plist settings.
         enforceStrictPlistSanityCheck = false

--- a/samples/compose-passkey/src/iosMain/kotlin/dev/webauthn/samples/composepasskey/PlatformProviders.ios.kt
+++ b/samples/compose-passkey/src/iosMain/kotlin/dev/webauthn/samples/composepasskey/PlatformProviders.ios.kt
@@ -12,7 +12,7 @@ import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 
 @Composable
-public actual fun rememberPlatformHttpClient(onLogLine: (String) -> Unit): HttpClient {
+actual fun rememberPlatformHttpClient(onLogLine: (String) -> Unit): HttpClient {
     return remember(onLogLine) {
         HttpClient(Darwin) {
             install(ContentNegotiation) {
@@ -35,6 +35,6 @@ public actual fun rememberPlatformHttpClient(onLogLine: (String) -> Unit): HttpC
     }
 }
 
-public actual fun platformRuntimeHint(): String? {
+actual fun platformRuntimeHint(): String? {
     return "Passkey register/sign-in may fail unless Associated Domains entitlement and a matching apple-app-site-association setup are configured."
 }

--- a/samples/ios-passkey/src/commonMain/kotlin/dev/webauthn/samples/ios/SampleClient.kt
+++ b/samples/ios-passkey/src/commonMain/kotlin/dev/webauthn/samples/ios/SampleClient.kt
@@ -2,6 +2,6 @@ package dev.webauthn.samples.ios
 
 import dev.webauthn.client.ios.IosPasskeyClient
 
-public class SampleClient {
-    public val passkeyClient: IosPasskeyClient = IosPasskeyClient()
+class SampleClient {
+    val passkeyClient: IosPasskeyClient = IosPasskeyClient()
 }

--- a/samples/ios-passkey/src/iosMain/kotlin/dev/webauthn/samples/ios/Entrypoint.kt
+++ b/samples/ios-passkey/src/iosMain/kotlin/dev/webauthn/samples/ios/Entrypoint.kt
@@ -1,3 +1,3 @@
 package dev.webauthn.samples.ios
 
-public const val SAMPLE_ENTRYPOINT_MESSAGE: String = "WebAuthn iOS sample initialized"
+const val SAMPLE_ENTRYPOINT_MESSAGE: String = "WebAuthn iOS sample initialized"


### PR DESCRIPTION
## Summary
- apply sample policy boundary so `explicitApi()` no longer applies to `:samples:*`
- remove explicit `public` visibility modifiers across sample modules where they are redundant
- mark PR1 as completed in the client sample rework execution map

## Scope
This PR intentionally covers only PR1 from `docs/ai/CLIENT_SAMPLE_REWORK_EXECUTION_MAP.md`.

## Validation
- `tools/agent/quality-gate.sh --mode fast --scope changed --block false` (cannot run on this host due to `mapfile` shell compatibility issue in `tools/agent/changed-modules.sh`)
- `tools/agent/quality-gate.sh --mode strict --scope changed --block false` (same host issue)
- compiled touched sample modules with Gradle:
  - `:samples:android-passkey:compileDebugKotlin`
  - `:samples:compose-passkey-android:compileDebugKotlin`
  - `:samples:compose-passkey:compileKotlinMetadata`
  - `:samples:compose-passkey:compileKotlinIosSimulatorArm64`
  - `:samples:ios-passkey:compileKotlinMetadata`
  - `:samples:ios-passkey:compileKotlinIosSimulatorArm64`

## Notes
- broader PR2+ WIP remains intentionally out of this branch to keep PR1 small/reviewable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reduced public visibility across sample code components, including composable functions, data classes, and platform-specific implementations, to limit the public API surface of samples.

* **Chores**
  * Modified build configuration to conditionally apply explicit API visibility rules, excluding sample projects from strict requirements.
  * Updated execution tracking documentation to reflect completed milestone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->