### PR TITLE
samples(compose): hidden debug sheet + secret double-tap trigger (PR4)

### DIFF
--- a/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/components/DebugLogSheet.kt
+++ b/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/components/DebugLogSheet.kt
@@ -1,0 +1,22 @@
+package dev.webauthn.samples.composepasskey.ui.components
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.runtime.Composable
+import dev.webauthn.samples.composepasskey.model.DebugLogEntry
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DebugLogSheet(
+    entries: List<DebugLogEntry>,
+    sheetState: SheetState,
+    onDismissRequest: () -> Unit,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState,
+    ) {
+        DebugLogCard(entries = entries)
+    }
+}

--- a/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/components/Header.kt
+++ b/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/components/Header.kt
@@ -1,5 +1,6 @@
 package dev.webauthn.samples.composepasskey.ui.components
 
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -10,11 +11,24 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 import dev.webauthn.samples.composepasskey.model.PasskeyDemoStatus
 
 @Composable
-fun Header(status: PasskeyDemoStatus) {
+fun Header(
+    status: PasskeyDemoStatus,
+    onTitleDoubleTap: (() -> Unit)? = null,
+) {
+    val titleModifier =
+        if (onTitleDoubleTap == null) {
+            Modifier
+        } else {
+            Modifier.pointerInput(onTitleDoubleTap) {
+                detectTapGestures(onDoubleTap = { onTitleDoubleTap() })
+            }
+        }
+
     ElevatedCard(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.elevatedCardColors(containerColor = MaterialTheme.colorScheme.surface),
@@ -26,6 +40,7 @@ fun Header(status: PasskeyDemoStatus) {
             Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                 Text(
                     text = "WebAuthn Kotlin Demo",
+                    modifier = titleModifier,
                     style = MaterialTheme.typography.headlineLarge,
                     color = MaterialTheme.colorScheme.primary,
                 )

--- a/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/screens/LoggedInScreen.kt
+++ b/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/screens/LoggedInScreen.kt
@@ -9,19 +9,26 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import dev.webauthn.samples.composepasskey.model.DebugLogEntry
 import dev.webauthn.samples.composepasskey.model.PasskeyDemoStatus
 import dev.webauthn.samples.composepasskey.model.StatusTone
 import dev.webauthn.samples.composepasskey.ui.components.CapabilitiesCard
-import dev.webauthn.samples.composepasskey.ui.components.DebugLogCard
+import dev.webauthn.samples.composepasskey.ui.components.DebugLogSheet
 import dev.webauthn.samples.composepasskey.ui.components.Header
 import dev.webauthn.samples.composepasskey.ui.components.PrfCryptoCard
 import dev.webauthn.samples.composepasskey.ui.components.SessionActionsCard
 import dev.webauthn.samples.composepasskey.ui.state.LoggedInUiState
 
 @Composable
+@OptIn(ExperimentalMaterial3Api::class)
 internal fun LoggedInScreen(
     state: LoggedInUiState,
     debugEntries: List<DebugLogEntry>,
@@ -32,6 +39,17 @@ internal fun LoggedInScreen(
     onPlaintextChange: (String) -> Unit,
     onLogout: () -> Unit,
 ) {
+    var showDebugSheet by remember { mutableStateOf(false) }
+    val debugSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    if (showDebugSheet) {
+        DebugLogSheet(
+            entries = debugEntries,
+            sheetState = debugSheetState,
+            onDismissRequest = { showDebugSheet = false },
+        )
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -45,6 +63,7 @@ internal fun LoggedInScreen(
                 headline = "Signed in",
                 detail = "Extension demo area is now active.",
             ),
+            onTitleDoubleTap = { showDebugSheet = true },
         )
 
         CapabilitiesCard(
@@ -69,8 +88,6 @@ internal fun LoggedInScreen(
             busy = state.busy,
             onLogout = onLogout,
         )
-
-        DebugLogCard(entries = debugEntries)
         Spacer(modifier = Modifier.height(20.dp))
     }
 }


### PR DESCRIPTION
## Summary
- hide compose sample debug logs behind a modal bottom sheet instead of showing them inline
- add a secret trigger (double-tap on the header title) to reveal logs
- keep log rendering state-driven and scoped to UI state in `LoggedInScreen`

## Changes
- add new `DebugLogSheet` composable wrapping `ModalBottomSheet`
- wire `LoggedInScreen` local state to show/hide `DebugLogSheet`
- remove always-visible `DebugLogCard` from the logged-in layout
- extend `Header` with optional `onTitleDoubleTap` callback and pointer gesture handling

## Validation
- `tools/agent/quality-gate.sh --mode fast --scope changed --block false`
- `tools/agent/quality-gate.sh --mode strict --scope changed --block false`
