### PR TITLE
samples(compose): add preview catalog + preview-safe docs/tooling (PR5)

### DIFF
--- a/docs/ai/CLIENT_SAMPLE_REWORK_EXECUTION_MAP.md
+++ b/docs/ai/CLIENT_SAMPLE_REWORK_EXECUTION_MAP.md
@@ -3,7 +3,7 @@
 Status: Active  
 Owner: `@ai-agent` (paired with maintainers)  
 Started: 2026-03-29  
-Target branch strategy: stacked PRs targeting `client-sample-rework-dev`, then one integration PR from `client-sample-rework-dev` to `main`
+Target branch strategy: stacked PRs where each PR targets the previous PR branch; final PR rebases to `main` and removes temporary tracker docs.
 
 ## Goal
 
@@ -17,15 +17,15 @@ Deliver the client sample rework in six reviewable PRs while keeping sample-only
 
 ## Branch and PR Queue
 
-Each PR below should target `client-sample-rework-dev`.
+Each PR below stacks on the previous PR branch unless explicitly noted.
 
 | PR | Branch | Status | Link | Scope | Exit Criteria |
 | --- | --- | --- | --- | --- | --- |
 | 1 | `client-sample-rework-pr1-policy-visibility` | Completed | [#95](https://github.com/szijpeter/webauthn-kotlin-multiplatform/pull/95) | Sample policy boundary + visibility cleanup (`explicitApi` exclusion for samples, remove unnecessary `public`) | Sample modules compile with preserved host entrypoints and no accidental public-surface changes. |
 | 2 | `client-sample-rework-pr2-foundation` | Completed | [#96](https://github.com/szijpeter/webauthn-kotlin-multiplatform/pull/96) | Compose sample architecture skeleton (MVVM+UDF), typed routes, Navigation 3 setup, Koin graph, orchestration split out of monolithic `App()` | Compose sample compiles for Android and iOS simulator targets with new architecture wiring in place and no feature regressions. |
 | 3 | `client-sample-rework-pr3-auth-session` | Completed | [#97](https://github.com/szijpeter/webauthn-kotlin-multiplatform/pull/97) | Real login flow with `Auth` and `LoggedIn` screens, local session model, local logout behavior | Register/sign-in/logout transitions are deterministic in ViewModel tests and manual smoke checks. |
-| 4 | `client-sample-rework-pr4-debug-structure` | Planned | - | Hidden debug logs in bottom sheet via secret trigger, composable file-structure discipline, state-driven renderers | Debug sheet remains hidden by default, opens via secret trigger, and composable boundaries follow one reusable `internal` composable per file. |
-| 5 | `client-sample-rework-pr5-previews` | Planned | - | Preview catalog + preview-safe UI contracts + tooling setup + preview limitations doc | Previews render with fake/static data and compile paths stay free of DI/network/platform runtime dependencies. |
+| 4 | `client-sample-rework-pr4-debug-structure` | Completed | [#99](https://github.com/szijpeter/webauthn-kotlin-multiplatform/pull/99) | Hidden debug logs in bottom sheet via secret trigger, composable file-structure discipline, state-driven renderers | Debug sheet remains hidden by default, opens via secret trigger, and composable boundaries follow one reusable `internal` composable per file. |
+| 5 | `client-sample-rework-pr5-previews` | In Progress | - | Preview catalog + preview-safe UI contracts + tooling setup + preview limitations doc | Previews render with fake/static data and compile paths stay free of DI/network/platform runtime dependencies. |
 | 6 | `client-sample-rework-pr6-docs-roadmap` | Planned | - | README/readiness updates, roadmap backlog items, execution-map closure | Docs reflect new flow/behavior, roadmap entries exist, and execution map is closed with next-action pointers. |
 
 ## Validation Gates (Per PR)
@@ -51,6 +51,5 @@ Each PR below should target `client-sample-rework-dev`.
 
 ## Completion Criteria
 
-- PR1-PR6 merged into `client-sample-rework-dev`.
-- Integration PR from `client-sample-rework-dev` to `main` is ready.
-- This execution-map file is updated to `Status: Complete` and then removed in cleanup once effort is fully landed.
+- PR1-PR6 merged into `main` via the stacked sequence.
+- Final PR includes cleanup/removal of this temporary execution-map file.

--- a/samples/compose-passkey/README.md
+++ b/samples/compose-passkey/README.md
@@ -10,7 +10,7 @@ Compose Multiplatform sample app for a minimal passkey E2E flow against `samples
 4. Controller-driven lifecycle state (`PasskeyControllerState`) driving UI status and action enablement.
 5. Direct sample wiring to `KtorPasskeyServerClient` default backend contract.
 6. PRF crypto demo flow: caller-owned salt load/generation, `Sign In + PRF`, session key derivation, AES-GCM encrypt/decrypt, and explicit session clear.
-7. Single logger-backed debug log panel in UI (wall-clock timestamps, level, source, message).
+7. Hidden logger-backed debug log sheet in UI (wall-clock timestamps, level, source, message), revealed by secret title double-tap.
 8. Structured ceremony + network logs emitted with tag `PasskeyDemo`.
 
 Build-time config is shared across Android and iOS (not platform-specific). These env vars are baked into the app during build:
@@ -85,7 +85,7 @@ Full E2E expectation:
 
 ## Debug logging
 
-The sample emits structured logs with tag `PasskeyDemo` and uses the same entries for the in-app debug panel:
+The sample emits structured logs with tag `PasskeyDemo` and uses the same entries for the hidden in-app debug sheet:
 
 - `app`: startup and configuration
 - `capabilities`: probe start/success/failure
@@ -98,6 +98,21 @@ To inspect logs:
 
 - Android: `adb logcat | grep PasskeyDemo`
 - iOS: Xcode/device console output (`NSLog`)
+- In-app: double-tap the `WebAuthn Kotlin Demo` header title on the signed-in screen to reveal the debug sheet.
+
+## Compose previews
+
+Preview catalog composables live in common source:
+
+- `src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/previews/ScreenPreviewCatalog.kt`
+- `src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/previews/ComponentPreviewCatalog.kt`
+
+Preview limitations and constraints:
+
+1. Previews are static and fake-state only; they must stay free of DI (`koin*`), network clients, and platform runtime calls.
+2. Interactive runtime flows (Navigation 3 back stack, passkey platform prompts, live bottom-sheet gestures) are not fully represented in preview mode.
+3. Android Studio rendering still relies on Android target preview tooling, so `androidMain` includes `compose.ui.tooling` for this module.
+4. Treat previews as UI contract checks, not behavioral verification; lifecycle/interop behavior must still be validated via tests and host-app runs.
 
 ## Test layering (fake vs real client)
 

--- a/samples/compose-passkey/build.gradle.kts
+++ b/samples/compose-passkey/build.gradle.kts
@@ -52,6 +52,7 @@ kotlin {
         }
 
         androidMain.dependencies {
+            implementation(libs.compose.ui.tooling)
             implementation(libs.ktor.client.okhttp)
         }
 

--- a/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/previews/ComponentPreviewCatalog.kt
+++ b/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/previews/ComponentPreviewCatalog.kt
@@ -1,0 +1,178 @@
+package dev.webauthn.samples.composepasskey.ui.previews
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import dev.webauthn.client.PasskeyCapabilities
+import dev.webauthn.client.PasskeyCapability
+import dev.webauthn.model.WebAuthnExtension
+import dev.webauthn.samples.composepasskey.PrfCryptoDemoSessionState
+import dev.webauthn.samples.composepasskey.model.DebugLogEntry
+import dev.webauthn.samples.composepasskey.model.DebugLogLevel
+import dev.webauthn.samples.composepasskey.model.PasskeyDemoStatus
+import dev.webauthn.samples.composepasskey.model.StatusTone
+import dev.webauthn.samples.composepasskey.ui.components.ActionsCard
+import dev.webauthn.samples.composepasskey.ui.components.CapabilitiesCard
+import dev.webauthn.samples.composepasskey.ui.components.DebugLogCard
+import dev.webauthn.samples.composepasskey.ui.components.Header
+import dev.webauthn.samples.composepasskey.ui.components.PrfCryptoCard
+import dev.webauthn.samples.composepasskey.ui.components.SessionActionsCard
+import dev.webauthn.samples.composepasskey.ui.theme.EditorialPalette
+import dev.webauthn.samples.composepasskey.ui.theme.EditorialTypography
+import kotlin.time.Instant
+
+@Preview(name = "Header")
+@Composable
+private fun HeaderPreview() {
+    PreviewSurface {
+        Header(
+            status = PasskeyDemoStatus(
+                tone = StatusTone.SUCCESS,
+                headline = "Signed in",
+                detail = "Extension demo area is now active.",
+            ),
+        )
+    }
+}
+
+@Preview(name = "Actions Card")
+@Composable
+private fun ActionsCardPreview() {
+    PreviewSurface {
+        ActionsCard(
+            actionsEnabled = true,
+            onRegister = {},
+            onSignIn = {},
+        )
+    }
+}
+
+@Preview(name = "Capabilities Card")
+@Composable
+private fun CapabilitiesCardPreview() {
+    PreviewSurface {
+        CapabilitiesCard(
+            capabilities = PasskeyCapabilities(
+                supported = setOf(
+                    PasskeyCapability.Extension(WebAuthnExtension.Prf),
+                    PasskeyCapability.Extension(WebAuthnExtension.LargeBlob),
+                ),
+                platformVersionHints = listOf("ios 18.2", "platform passkeys enabled"),
+            ),
+        )
+    }
+}
+
+@Preview(name = "PRF Crypto Card")
+@Composable
+private fun PrfCryptoCardPreview() {
+    PreviewSurface {
+        PrfCryptoCard(
+            modifier = Modifier.fillMaxWidth(),
+            supportsPrf = true,
+            actionsEnabled = true,
+            sessionState = PrfCryptoDemoSessionState.CiphertextReady,
+            plaintext = "Top secret from passkey PRF",
+            decryptedText = "Top secret from passkey PRF",
+            statusMessage = "Encrypted 27 chars to 32 bytes.",
+            onPlaintextChange = {},
+            onSignInWithPrf = {},
+            onEncrypt = {},
+            onDecrypt = {},
+            onClearSession = {},
+        )
+    }
+}
+
+@Preview(name = "Session Actions Card")
+@Composable
+private fun SessionActionsCardPreview() {
+    PreviewSurface {
+        SessionActionsCard(
+            busy = false,
+            onLogout = {},
+        )
+    }
+}
+
+@Preview(name = "Debug Log Card")
+@Composable
+private fun DebugLogCardPreview() {
+    PreviewSurface {
+        DebugLogCard(
+            entries = listOf(
+                DebugLogEntry(
+                    id = 1L,
+                    timestamp = Instant.parse("2026-03-30T10:01:10Z"),
+                    level = DebugLogLevel.INFO,
+                    source = "action",
+                    message = "Sign In tapped",
+                ),
+                DebugLogEntry(
+                    id = 2L,
+                    timestamp = Instant.parse("2026-03-30T10:01:11Z"),
+                    level = DebugLogLevel.WARN,
+                    source = "capabilities",
+                    message = "PRF extension not supported on this profile.",
+                ),
+                DebugLogEntry(
+                    id = 3L,
+                    timestamp = Instant.parse("2026-03-30T10:01:13Z"),
+                    level = DebugLogLevel.ERROR,
+                    source = "http",
+                    message = "Request failed: 401 unauthorized",
+                ),
+            ),
+        )
+    }
+}
+
+@Preview(name = "Preview Catalog")
+@Composable
+private fun ComponentCatalogPreview() {
+    PreviewSurface {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+        ) {
+            Header(
+                status = PasskeyDemoStatus(
+                    tone = StatusTone.IDLE,
+                    headline = "Ready",
+                ),
+            )
+            SpacerBlock()
+            ActionsCard(actionsEnabled = true, onRegister = {}, onSignIn = {})
+            SpacerBlock()
+            SessionActionsCard(busy = false, onLogout = {})
+        }
+    }
+}
+
+@Composable
+private fun SpacerBlock() {
+    Spacer(
+        modifier = Modifier.size(12.dp),
+    )
+}
+
+@Composable
+private fun PreviewSurface(content: @Composable () -> Unit) {
+    MaterialTheme(
+        colorScheme = EditorialPalette,
+        typography = EditorialTypography,
+    ) {
+        Surface {
+            content()
+        }
+    }
+}

--- a/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/previews/ScreenPreviewCatalog.kt
+++ b/samples/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/previews/ScreenPreviewCatalog.kt
@@ -1,0 +1,118 @@
+package dev.webauthn.samples.composepasskey.ui.previews
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import dev.webauthn.client.PasskeyCapabilities
+import dev.webauthn.client.PasskeyCapability
+import dev.webauthn.model.WebAuthnExtension
+import dev.webauthn.samples.composepasskey.PrfCryptoDemoSessionState
+import dev.webauthn.samples.composepasskey.model.DebugLogEntry
+import dev.webauthn.samples.composepasskey.model.DebugLogLevel
+import dev.webauthn.samples.composepasskey.model.PasskeyDemoStatus
+import dev.webauthn.samples.composepasskey.model.StatusTone
+import dev.webauthn.samples.composepasskey.ui.screens.AuthScreen
+import dev.webauthn.samples.composepasskey.ui.screens.LoggedInScreen
+import dev.webauthn.samples.composepasskey.ui.state.AuthUiState
+import dev.webauthn.samples.composepasskey.ui.state.LoggedInUiState
+import dev.webauthn.samples.composepasskey.ui.theme.EditorialPalette
+import dev.webauthn.samples.composepasskey.ui.theme.EditorialTypography
+import kotlin.time.Instant
+
+@Preview(name = "Auth Screen - Idle")
+@Composable
+private fun AuthScreenIdlePreview() {
+    PreviewSurface {
+        AuthScreen(
+            state = AuthUiState(
+                status = PasskeyDemoStatus(
+                    tone = StatusTone.IDLE,
+                    headline = "Ready",
+                    detail = "Tap Register or Sign In to begin.",
+                ),
+                actionsEnabled = true,
+            ),
+            onRegister = {},
+            onSignIn = {},
+        )
+    }
+}
+
+@Preview(name = "Auth Screen - Busy")
+@Composable
+private fun AuthScreenBusyPreview() {
+    PreviewSurface {
+        AuthScreen(
+            state = AuthUiState(
+                status = PasskeyDemoStatus(
+                    tone = StatusTone.WORKING,
+                    headline = "Platform prompt active",
+                    detail = "Complete the passkey prompt to continue.",
+                ),
+                actionsEnabled = false,
+                runtimeHint = "Security key provider appears unavailable on this device.",
+            ),
+            onRegister = {},
+            onSignIn = {},
+        )
+    }
+}
+
+@Preview(name = "Logged-In Screen")
+@Composable
+private fun LoggedInScreenPreview() {
+    PreviewSurface {
+        LoggedInScreen(
+            state = LoggedInUiState(
+                userName = "demo@local",
+                capabilities = PasskeyCapabilities(
+                    supported = setOf(
+                        PasskeyCapability.Extension(WebAuthnExtension.Prf),
+                        PasskeyCapability.PlatformFeature("securityKey"),
+                    ),
+                    platformVersionHints = listOf("android sdk=36", "play-services:available"),
+                ),
+                supportsPrf = true,
+                sessionState = PrfCryptoDemoSessionState.SessionReady,
+                plaintext = "Top secret from passkey PRF",
+                decryptedText = "Top secret from passkey PRF",
+                statusMessage = "Decrypt succeeded.",
+            ),
+            debugEntries = listOf(
+                DebugLogEntry(
+                    id = 1L,
+                    timestamp = Instant.parse("2026-03-30T09:41:22Z"),
+                    level = DebugLogLevel.INFO,
+                    source = "prf",
+                    message = "Session ready (fp=8f2c...).",
+                ),
+                DebugLogEntry(
+                    id = 2L,
+                    timestamp = Instant.parse("2026-03-30T09:41:25Z"),
+                    level = DebugLogLevel.DEBUG,
+                    source = "controller",
+                    message = "State moved to IDLE.",
+                ),
+            ),
+            onSignInWithPrf = {},
+            onEncrypt = {},
+            onDecrypt = {},
+            onClearPrfSession = {},
+            onPlaintextChange = {},
+            onLogout = {},
+        )
+    }
+}
+
+@Composable
+private fun PreviewSurface(content: @Composable () -> Unit) {
+    MaterialTheme(
+        colorScheme = EditorialPalette,
+        typography = EditorialTypography,
+    ) {
+        Surface {
+            content()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a common-source preview catalog for screens and reusable UI components in `samples:compose-passkey`
- keep preview contracts static/fake-state only (no DI/network/platform runtime wiring)
- document preview usage and limitations in the sample README
- update execution-map tracking for PR4 completion and PR5 in-progress status

## Changes
- add `ui/previews/ScreenPreviewCatalog.kt`
- add `ui/previews/ComponentPreviewCatalog.kt`
- wire Android preview tooling dependency in `androidMain`
- extend README with preview catalog location + CMP preview constraints

## Validation
- `tools/agent/quality-gate.sh --mode fast --scope changed --block false`
- `tools/agent/quality-gate.sh --mode strict --scope changed --block false`
