### PR TITLE
Exercise rotation-safe prompt context through Android bridge

### DIFF
--- a/webauthn-client-android/src/androidTest/kotlin/dev/webauthn/client/android/RotationSafePasskeyPromptContextTest.kt
+++ b/webauthn-client-android/src/androidTest/kotlin/dev/webauthn/client/android/RotationSafePasskeyPromptContextTest.kt
@@ -1,14 +1,29 @@
 package dev.webauthn.client.android
 
+import android.app.Application
+import android.app.PendingIntent
+import android.content.Context
+import android.os.CancellationSignal
 import androidx.activity.ComponentActivity
+import androidx.credentials.ClearCredentialStateRequest
+import androidx.credentials.CreateCredentialRequest
+import androidx.credentials.CreateCredentialResponse
+import androidx.credentials.CredentialManager
+import androidx.credentials.CredentialManagerCallback
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.GetCredentialResponse
+import androidx.credentials.PrepareGetCredentialResponse
+import androidx.credentials.exceptions.ClearCredentialException
+import androidx.credentials.exceptions.CreateCredentialCancellationException
+import androidx.credentials.exceptions.CreateCredentialException
+import androidx.credentials.exceptions.GetCredentialException
+import androidx.credentials.exceptions.GetCredentialCancellationException
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import dev.webauthn.client.PasskeyClient
-import dev.webauthn.client.PasskeyClientError
 import dev.webauthn.client.PasskeyController
 import dev.webauthn.client.PasskeyFinishResult
-import dev.webauthn.client.PasskeyResult
 import dev.webauthn.client.PasskeyServerClient
 import dev.webauthn.model.AuthenticationResponse
 import dev.webauthn.model.Challenge
@@ -22,33 +37,89 @@ import dev.webauthn.model.RegistrationResponse
 import dev.webauthn.model.RpId
 import dev.webauthn.model.UserHandle
 import dev.webauthn.model.ValidationResult
+import java.util.concurrent.Executor
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class RotationSafePasskeyPromptContextTest {
     @Test
-    fun register_after_recreate_uses_updated_prompt_context() {
+    fun register_after_recreate_uses_updated_prompt_context_via_android_bridge() {
         val scenario = ActivityScenario.launch(RuntimeHostActivity::class.java)
         try {
-            var firstContextId = -1
+            var firstActivityId = -1
+            var retainedViewModelId = -1
+
             scenario.onActivity { activity ->
+                firstActivityId = System.identityHashCode(activity)
+                retainedViewModelId = System.identityHashCode(activity.viewModel)
+
                 runBlocking { activity.viewModel.register() }
-                firstContextId = activity.viewModel.usedContextIdentityIds.single()
+
+                assertEquals(
+                    listOf(firstActivityId),
+                    activity.viewModel.registerPromptContextIdentityIds,
+                )
+                assertEquals(1, activity.viewModel.registerStartCalls)
             }
 
             scenario.recreate()
 
             scenario.onActivity { activity ->
+                val recreatedActivityId = System.identityHashCode(activity)
+                assertNotEquals(firstActivityId, recreatedActivityId)
+                assertEquals(retainedViewModelId, System.identityHashCode(activity.viewModel))
+
                 runBlocking { activity.viewModel.register() }
-                val contextIds = activity.viewModel.usedContextIdentityIds
+
+                val contextIds = activity.viewModel.registerPromptContextIdentityIds
                 assertEquals(2, contextIds.size)
-                assertNotEquals(firstContextId, contextIds.last())
-                assertTrue(activity.viewModel.registerStartCalls >= 2)
+                assertEquals(recreatedActivityId, contextIds.last())
+                assertNotEquals(firstActivityId, contextIds.last())
+                assertEquals(2, activity.viewModel.registerStartCalls)
+            }
+        } finally {
+            scenario.close()
+        }
+    }
+
+    @Test
+    fun sign_in_after_recreate_uses_updated_prompt_context_via_android_bridge() {
+        val scenario = ActivityScenario.launch(RuntimeHostActivity::class.java)
+        try {
+            var firstActivityId = -1
+            var retainedViewModelId = -1
+
+            scenario.onActivity { activity ->
+                firstActivityId = System.identityHashCode(activity)
+                retainedViewModelId = System.identityHashCode(activity.viewModel)
+
+                runBlocking { activity.viewModel.signIn() }
+
+                assertEquals(
+                    listOf(firstActivityId),
+                    activity.viewModel.signInPromptContextIdentityIds,
+                )
+                assertEquals(1, activity.viewModel.signInStartCalls)
+            }
+
+            scenario.recreate()
+
+            scenario.onActivity { activity ->
+                val recreatedActivityId = System.identityHashCode(activity)
+                assertNotEquals(firstActivityId, recreatedActivityId)
+                assertEquals(retainedViewModelId, System.identityHashCode(activity.viewModel))
+
+                runBlocking { activity.viewModel.signIn() }
+
+                val contextIds = activity.viewModel.signInPromptContextIdentityIds
+                assertEquals(2, contextIds.size)
+                assertEquals(recreatedActivityId, contextIds.last())
+                assertNotEquals(firstActivityId, contextIds.last())
+                assertEquals(2, activity.viewModel.signInStartCalls)
             }
         } finally {
             scenario.close()
@@ -57,71 +128,143 @@ class RotationSafePasskeyPromptContextTest {
 }
 
 class RuntimeHostActivity : ComponentActivity() {
-    val viewModel: RuntimeHostViewModel by lazy {
-        androidx.lifecycle.ViewModelProvider(this)[RuntimeHostViewModel::class.java]
-    }
-
-    override fun onResume() {
-        super.onResume()
-        viewModel.updateContext(this)
-    }
-
-    override fun onPause() {
-        viewModel.updateContext(null)
-        super.onPause()
+    val viewModel: RuntimeHostViewModel by lazy(LazyThreadSafetyMode.NONE) {
+        ViewModelProvider(
+            this,
+            RuntimeHostViewModel.factory(
+                application = application,
+                contextHint = this,
+            ),
+        )[RuntimeHostViewModel::class.java]
     }
 }
 
-class RuntimeHostViewModel : ViewModel() {
-    private val contextProvider = MutablePasskeyPromptContextProvider()
+class RuntimeHostViewModel(
+    application: Application,
+    contextHint: Context,
+) : ViewModel() {
+    private val credentialManager = RecordingCredentialManager()
     private val fakeServerClient = RuntimeTestServerClient()
-    private val fakePasskeyClient = RuntimeAwareFakePasskeyClient(contextProvider)
     private val controller = PasskeyController(
-        passkeyClient = fakePasskeyClient,
+        passkeyClient = AndroidPasskeyClient(
+            contextProvider = ForegroundActivityPasskeyPromptContextProvider.forApplication(
+                application = application,
+                contextHint = contextHint,
+            ),
+            credentialManagerFactory = { credentialManager },
+        ),
         serverClient = fakeServerClient,
     )
 
-    val usedContextIdentityIds: List<Int>
-        get() = fakePasskeyClient.usedContextIdentityIds.toList()
+    val registerPromptContextIdentityIds: List<Int>
+        get() = credentialManager.createContextIdentityIds.toList()
+
+    val signInPromptContextIdentityIds: List<Int>
+        get() = credentialManager.getContextIdentityIds.toList()
 
     val registerStartCalls: Int
         get() = fakeServerClient.registerStartCalls
 
-    fun updateContext(activity: ComponentActivity?) {
-        contextProvider.update(activity)
-    }
+    val signInStartCalls: Int
+        get() = fakeServerClient.signInStartCalls
 
     suspend fun register() {
-        controller.register(
-            "demo-user",
-        )
+        controller.register("demo-user")
+    }
+
+    suspend fun signIn() {
+        controller.signIn("demo-user")
+    }
+
+    companion object {
+        fun factory(
+            application: Application,
+            contextHint: Context,
+        ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                require(modelClass.isAssignableFrom(RuntimeHostViewModel::class.java)) {
+                    "Unsupported ViewModel class: ${modelClass.name}"
+                }
+                return RuntimeHostViewModel(
+                    application = application,
+                    contextHint = contextHint,
+                ) as T
+            }
+        }
     }
 }
 
-private class RuntimeAwareFakePasskeyClient(
-    private val contextProvider: MutablePasskeyPromptContextProvider,
-) : PasskeyClient {
-    val usedContextIdentityIds: MutableList<Int> = mutableListOf()
+private class RecordingCredentialManager : CredentialManager {
+    val createContextIdentityIds: MutableList<Int> = mutableListOf()
+    val getContextIdentityIds: MutableList<Int> = mutableListOf()
 
-    override suspend fun createCredential(
-        options: PublicKeyCredentialCreationOptions,
-    ): PasskeyResult<RegistrationResponse> {
-        val context = contextProvider.currentContextOrNull()
-            ?: return PasskeyResult.Failure(PasskeyClientError.Platform("No active UI context"))
-        usedContextIdentityIds += System.identityHashCode(context)
-        return PasskeyResult.Failure(PasskeyClientError.UserCancelled())
+    override fun createCredentialAsync(
+        context: Context,
+        request: CreateCredentialRequest,
+        cancellationSignal: CancellationSignal?,
+        executor: Executor,
+        callback: CredentialManagerCallback<CreateCredentialResponse, CreateCredentialException>,
+    ) {
+        createContextIdentityIds += System.identityHashCode(context)
+        executor.execute {
+            callback.onError(CreateCredentialCancellationException("Cancelled"))
+        }
     }
 
-    override suspend fun getAssertion(
-        options: PublicKeyCredentialRequestOptions,
-    ): PasskeyResult<AuthenticationResponse> {
-        return PasskeyResult.Failure(PasskeyClientError.UserCancelled())
+    override fun getCredentialAsync(
+        context: Context,
+        request: GetCredentialRequest,
+        cancellationSignal: CancellationSignal?,
+        executor: Executor,
+        callback: CredentialManagerCallback<GetCredentialResponse, GetCredentialException>,
+    ) {
+        getContextIdentityIds += System.identityHashCode(context)
+        executor.execute {
+            callback.onError(GetCredentialCancellationException("Cancelled"))
+        }
+    }
+
+    override fun getCredentialAsync(
+        context: Context,
+        pendingGetCredentialHandle: PrepareGetCredentialResponse.PendingGetCredentialHandle,
+        cancellationSignal: CancellationSignal?,
+        executor: Executor,
+        callback: CredentialManagerCallback<GetCredentialResponse, GetCredentialException>,
+    ) {
+        throw UnsupportedOperationException("Pending getCredential is not used in this test")
+    }
+
+    override fun prepareGetCredentialAsync(
+        request: GetCredentialRequest,
+        cancellationSignal: CancellationSignal?,
+        executor: Executor,
+        callback: CredentialManagerCallback<PrepareGetCredentialResponse, GetCredentialException>,
+    ) {
+        throw UnsupportedOperationException("prepareGetCredential is not used in this test")
+    }
+
+    override fun clearCredentialStateAsync(
+        request: ClearCredentialStateRequest,
+        cancellationSignal: CancellationSignal?,
+        executor: Executor,
+        callback: CredentialManagerCallback<Void?, ClearCredentialException>,
+    ) {
+        executor.execute {
+            callback.onResult(null)
+        }
+    }
+
+    override fun createSettingsPendingIntent(): PendingIntent {
+        throw UnsupportedOperationException("Settings pending intent is not used in this test")
     }
 }
 
-private class RuntimeTestServerClient :
-    PasskeyServerClient<String, String> {
+private class RuntimeTestServerClient : PasskeyServerClient<String, String> {
     var registerStartCalls: Int = 0
+        private set
+
+    var signInStartCalls: Int = 0
         private set
 
     override suspend fun getRegisterOptions(
@@ -159,6 +302,7 @@ private class RuntimeTestServerClient :
     override suspend fun getSignInOptions(
         params: String,
     ): ValidationResult<PublicKeyCredentialRequestOptions> {
+        signInStartCalls += 1
         return ValidationResult.Valid(
             PublicKeyCredentialRequestOptions(
                 challenge = Challenge.fromBytes(ByteArray(32) { 2 }),


### PR DESCRIPTION
## What changed
- rewrote `RotationSafePasskeyPromptContextTest` to exercise the retained-client flow through `AndroidPasskeyClient` and `AndroidPasskeyPlatformBridge`
- switched prompt-context resolution in the test to `ForegroundActivityPasskeyPromptContextProvider.forApplication(...)`
- faked only the `CredentialManager` boundary and recorded the actual activity-backed contexts used for both `register` and `signIn`
- removed the manual `viewModel.updateContext(...)` rebinding path from the test setup

## Why
Issue #105 called out that the old test bypassed the production prompt-context lookup path by reading a mutable provider directly. That meant the test could stay green even if the real bridge/provider integration regressed after `ActivityScenario.recreate()`.

## Impact
The test now verifies that a retained client still resolves a fresh activity-backed prompt context after recreation through the same runtime path production uses for both registration and sign-in.

## Validation
- `./gradlew :webauthn-client-android:compileDebugAndroidTestKotlin --stacktrace`
- `./gradlew :webauthn-client-android:detektDebugAndroidTestSourceSet :webauthn-client-android:compileDebugAndroidTestKotlin --stacktrace`

## Notes
- `tools/agent/quality-gate.sh --mode fast --scope changed --block false` and `--mode strict` were attempted in this workspace, but changed-scope currently includes an unrelated pre-existing edit in `samples/compose-passkey/.../Header.kt`, and the resulting iOS simulator linkage fails locally because `xcrun xcodebuild -version` is unavailable in this environment.

Refs #105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Enhanced test infrastructure for credential management operations with improved coverage of activity state handling and credential scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->