### PR TITLE
Add project wiki scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ tools/agent/quality-gate.sh --mode strict --scope changed --block false
 
 ## Related Docs
 
+- [`docs/wiki/README.md`](./docs/wiki/README.md)
 - [`docs/CLIENT_FIRST_EXECUTION.md`](./docs/CLIENT_FIRST_EXECUTION.md)
 - [`docs/CLIENT_API_BENCHMARKS.md`](./docs/CLIENT_API_BENCHMARKS.md)
 - [`docs/IMPLEMENTATION_STATUS.md`](./docs/IMPLEMENTATION_STATUS.md)

--- a/docs/wiki/AGENTS.md
+++ b/docs/wiki/AGENTS.md
@@ -1,0 +1,81 @@
+# Wiki Maintenance Schema
+
+This file defines how agents should maintain `docs/wiki/`.
+
+Repository-wide policy remains authoritative in [`docs/ai/STEERING.md`](../ai/STEERING.md). This file only adds wiki-specific structure and workflow.
+
+## Purpose
+
+This is a project wiki, not a personal wiki.
+
+The goal is to keep a compact, cross-linked knowledge layer above the repository's canonical source documents so future contributors can answer questions quickly without rediscovering the same context.
+
+## Three Layers
+
+1. Raw sources
+   - Canonical project docs under `docs/`
+   - Root `README.md`
+   - Module and sample `README.md` files
+   - `spec-cache/` and `spec-notes/`
+   - Relevant build files and source code
+2. Wiki
+   - Markdown pages in `docs/wiki/`
+   - These pages summarize, connect, and contextualize raw sources
+3. Schema
+   - This file plus repository-level agent guidance
+
+Agents may summarize and cross-link raw sources, but should not treat the wiki as more authoritative than the original files it cites.
+
+## Operations
+
+### Ingest
+
+When new project docs, modules, samples, or major implementation changes land:
+
+1. Read the changed source docs first.
+2. Update the most relevant existing wiki pages before creating new ones.
+3. Add new pages only when a concept cannot fit cleanly into the current structure.
+4. Update [`index.md`](./index.md) if page inventory or summaries changed.
+5. Append an exact-date entry to [`log.md`](./log.md).
+
+### Query
+
+When answering questions from the wiki:
+
+1. Read [`index.md`](./index.md) first.
+2. Open the most relevant wiki pages.
+3. Follow links back to raw sources when precision or freshness matters.
+4. Prefer exact dates over relative time words.
+
+### Lint
+
+Periodically check for:
+
+- stale status statements
+- pages that duplicate each other
+- missing links between related pages
+- wiki claims that no longer match canonical docs
+- module or sample additions not reflected in [`module-map.md`](./module-map.md) or [`index.md`](./index.md)
+
+## Page Conventions
+
+- Keep pages short and synthesis-oriented.
+- Use relative markdown links between wiki pages and back to source docs.
+- Prefer exact module names and exact dates.
+- Note when a page reflects current status rather than a permanent architectural truth.
+- Avoid copying large code examples from source docs unless they are essential.
+- Preserve append-only behavior in [`log.md`](./log.md).
+
+## Current Page Set
+
+- `README.md`: human landing page
+- `index.md`: wiki catalog
+- `log.md`: chronological change log
+- `project-overview.md`: repo mission and quick orientation
+- `module-map.md`: module families and adoption paths
+- `client-stack.md`: client architecture and integration flow
+- `server-stack.md`: server architecture and integration flow
+- `samples-and-demos.md`: runnable reference apps and demos
+- `quality-and-release.md`: quality gates, compatibility, release workflow
+- `status-and-roadmap.md`: maturity snapshot and priorities
+- `specs-and-sources.md`: standards and canonical source map

--- a/docs/wiki/AGENTS.md
+++ b/docs/wiki/AGENTS.md
@@ -60,7 +60,7 @@ Periodically check for:
 ## Page Conventions
 
 - Keep pages short and synthesis-oriented.
-- Use relative markdown links between wiki pages and back to source docs.
+- Use relative Markdown links between wiki pages and back to source docs.
 - Prefer exact module names and exact dates.
 - Note when a page reflects current status rather than a permanent architectural truth.
 - Avoid copying large code examples from source docs unless they are essential.

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -1,0 +1,23 @@
+# Project Wiki
+
+This directory is a project wiki for `webauthn-kotlin-multiplatform`.
+
+It follows the [LLM wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f), but adapted for a repository-maintained project wiki instead of a personal knowledge base:
+
+- Raw sources stay in the rest of the repository: root docs, module `README.md` files, `spec-cache/`, `spec-notes/`, build files, and code.
+- The wiki in `docs/wiki/` is the synthesized layer: short, cross-linked pages that explain how the project fits together.
+- The schema for maintaining this wiki lives in [`AGENTS.md`](./AGENTS.md).
+
+Start here:
+
+- [`index.md`](./index.md): catalog of wiki pages.
+- [`project-overview.md`](./project-overview.md): what the project is and how to orient quickly.
+- [`module-map.md`](./module-map.md): module families, publication boundaries, and adoption paths.
+- [`client-stack.md`](./client-stack.md): shared and platform client flow.
+- [`server-stack.md`](./server-stack.md): server, crypto, storage, and Ktor adapter flow.
+- [`quality-and-release.md`](./quality-and-release.md): quality gates, API compatibility, and release posture.
+- [`status-and-roadmap.md`](./status-and-roadmap.md): current maturity and next priorities.
+- [`specs-and-sources.md`](./specs-and-sources.md): normative standards and high-value repo source docs.
+- [`log.md`](./log.md): append-only record of wiki changes.
+
+Use this wiki as the navigation layer. When detail matters, follow links back to the canonical source files.

--- a/docs/wiki/client-stack.md
+++ b/docs/wiki/client-stack.md
@@ -1,0 +1,55 @@
+# Client Stack
+
+Last reviewed: 2026-04-06
+
+The client side is organized around shared orchestration in common Kotlin code, with thin platform bridges on Android and iOS.
+
+## Core Shape
+
+- `webauthn-client-core` owns the shared ceremony logic and typed client APIs.
+- `webauthn-client-android` bridges into Credential Manager.
+- `webauthn-client-ios` bridges into AuthenticationServices.
+- `webauthn-client-compose` provides remembered helpers for Compose-driven apps.
+- `webauthn-client-json-core` is an optional raw JSON interop layer.
+- `webauthn-network-ktor-client` is the default transport helper for `/webauthn/*` backends.
+- `webauthn-client-prf-crypto` adds PRF-derived application crypto helpers on top of passkey flows.
+
+## Practical Flow
+
+1. The host app asks the backend for start options.
+2. Shared client orchestration validates/maps those inputs into a platform-ready flow.
+3. Android or iOS platform APIs perform the passkey prompt.
+4. Shared client code maps the platform result back into a typed finish payload.
+5. The app sends the finish payload to the backend.
+
+Compose apps can keep most of the view-facing wiring in `rememberPasskeyClient(...)` and `rememberPasskeyController(...)`.
+
+## Important Boundaries
+
+- Shared business logic belongs in `webauthn-client-core`.
+- Platform modules should stay narrow and mostly concerned with OS API translation and error mapping.
+- JSON interop is optional and separate from the typed core.
+- Transport is optional and should not be mistaken for the client core itself.
+
+## Current Status Snapshot
+
+From the current implementation/status docs:
+
+- shared typed client orchestration is in place
+- Android and iOS bridges are usable and deliberately thin
+- Compose helpers exist for retained-controller usage
+- PRF helpers are available for apps that need post-auth crypto material
+- more device/provider/runtime matrix hardening is still expected, especially around platform-specific behavior
+
+## Where To Go Next
+
+- For the backend side of the same ceremony, read [`server-stack.md`](./server-stack.md).
+- For runnable examples, read [`samples-and-demos.md`](./samples-and-demos.md).
+- For maturity and next priorities, read [`status-and-roadmap.md`](./status-and-roadmap.md).
+
+## Canonical Source Anchors
+
+- Root client adoption section: [`README.md`](../../README.md)
+- Client-first execution notes: [`docs/CLIENT_FIRST_EXECUTION.md`](../CLIENT_FIRST_EXECUTION.md)
+- Client benchmark notes: [`docs/CLIENT_API_BENCHMARKS.md`](../CLIENT_API_BENCHMARKS.md)
+- Sample Compose app: [`samples/compose-passkey/README.md`](../../samples/compose-passkey/README.md)

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -1,0 +1,28 @@
+# Wiki Index
+
+Last refreshed: 2026-04-06
+
+This index is the main catalog for the project wiki. Read it first, then drill into the relevant pages.
+
+## Orientation
+
+- [`README.md`](./README.md): explains the purpose and structure of the wiki.
+- [`project-overview.md`](./project-overview.md): project mission, intended adopters, and the fastest orientation path.
+- [`specs-and-sources.md`](./specs-and-sources.md): normative specs and the repository documents that act as source material.
+
+## Architecture
+
+- [`module-map.md`](./module-map.md): published module families, layer boundaries, and recommended adoption paths.
+- [`client-stack.md`](./client-stack.md): shared client orchestration, platform bridges, Compose integration, and transport helpers.
+- [`server-stack.md`](./server-stack.md): validation, crypto, ceremony services, storage, Ktor routes, and attestation trust sources.
+
+## Delivery
+
+- [`samples-and-demos.md`](./samples-and-demos.md): runnable reference apps, demo backend, and the sample contract.
+- [`quality-and-release.md`](./quality-and-release.md): quality gates, API compatibility checks, publish preflight, and release-train rules.
+- [`status-and-roadmap.md`](./status-and-roadmap.md): current maturity snapshot, immediate priorities, and near-term roadmap.
+
+## Maintenance
+
+- [`AGENTS.md`](./AGENTS.md): schema and maintenance workflow for this wiki.
+- [`log.md`](./log.md): append-only timeline of wiki updates.

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -1,0 +1,7 @@
+# Wiki Log
+
+## [2026-04-06] bootstrap | Initial project wiki scaffold
+
+- Created `docs/wiki/` as a synthesized project-wiki layer above canonical repository docs.
+- Added the initial schema, index, and orientation pages for architecture, client/server stacks, samples, quality, status, and standards sources.
+- Seeded the wiki from current repository docs, module READMEs, roadmap, implementation status, and steering guidance.

--- a/docs/wiki/module-map.md
+++ b/docs/wiki/module-map.md
@@ -1,0 +1,70 @@
+# Module Map
+
+Last reviewed: 2026-04-06
+
+The repository uses a layered module model. Core protocol and validation concerns stay separate from crypto, server services, transport adapters, and platform clients.
+
+## Layer Model
+
+| Layer | Key modules | Role |
+| --- | --- | --- |
+| Protocol model | `webauthn-model` | Typed WebAuthn protocol and value wrappers |
+| Validation and serialization | `webauthn-core`, `webauthn-serialization-kotlinx`, `webauthn-cbor-core`, `webauthn-runtime-core` | Validation, parsing, DTO mapping, and shared runtime helpers |
+| Crypto | `webauthn-crypto-api`, `webauthn-server-jvm-crypto` | Crypto contracts plus JVM attestation/signature implementation |
+| Server | `webauthn-server-core-jvm`, `webauthn-server-ktor`, `webauthn-server-store-exposed`, `webauthn-attestation-mds` | Ceremony services, route adapters, persistence adapters, optional trust metadata |
+| Client | `webauthn-client-core`, `webauthn-client-json-core`, `webauthn-client-compose`, `webauthn-client-android`, `webauthn-client-ios`, `webauthn-client-prf-crypto`, `webauthn-network-ktor-client` | Shared client logic, platform bridges, Compose helpers, transport, and PRF crypto helpers |
+
+## Published Surface
+
+The published artifact surface is coordinated as one release train. The main published families are:
+
+- BOM: `platform:bom`
+- Foundation: `webauthn-cbor-core`, `webauthn-model`, `webauthn-runtime-core`, `webauthn-serialization-kotlinx`, `webauthn-core`
+- Crypto and server: `webauthn-crypto-api`, `webauthn-server-jvm-crypto`, `webauthn-server-core-jvm`, `webauthn-server-ktor`, `webauthn-server-store-exposed`, `webauthn-attestation-mds`
+- Client: `webauthn-client-core`, `webauthn-client-json-core`, `webauthn-client-compose`, `webauthn-client-android`, `webauthn-client-ios`, `webauthn-client-prf-crypto`, `webauthn-network-ktor-client`
+
+Not published:
+
+- `platform:constraints`
+- `samples:*`
+- `build-logic`
+
+## Recommended Adoption Paths
+
+### Server-first
+
+- `webauthn-model`
+- `webauthn-core`
+- `webauthn-crypto-api`
+- `webauthn-server-jvm-crypto`
+- `webauthn-server-core-jvm`
+- optional: `webauthn-server-ktor`
+- optional: `webauthn-server-store-exposed`
+- optional: `webauthn-attestation-mds`
+
+### Client-first
+
+- `webauthn-client-core`
+- optional: `webauthn-client-json-core`
+- `webauthn-client-android` and/or `webauthn-client-ios`
+- optional: `webauthn-client-compose`
+- optional: `webauthn-network-ktor-client`
+- optional: `webauthn-client-prf-crypto`
+
+### Mixed app + backend adoption
+
+Use [`platform/bom/README.md`](../../platform/bom/README.md) to keep versions aligned across published artifacts.
+
+## Design Rules Worth Remembering
+
+- `webauthn-model` and `webauthn-core` must remain free of platform and network dependencies.
+- `webauthn-client-core` owns shared client business logic; Android and iOS modules stay thin.
+- Ktor modules are adapters, not the core business layer.
+- Optional trust sources like MDS should remain separable from the main validation path.
+
+## Canonical Source Anchors
+
+- Root architecture section: [`README.md`](../../README.md)
+- Architecture doc: [`docs/architecture.md`](../architecture.md)
+- Published surface policy: [`docs/ai/STEERING.md`](../ai/STEERING.md)
+- Settings module list: [`settings.gradle.kts`](../../settings.gradle.kts)

--- a/docs/wiki/project-overview.md
+++ b/docs/wiki/project-overview.md
@@ -1,0 +1,46 @@
+# Project Overview
+
+Last reviewed: 2026-04-06
+
+`webauthn-kotlin-multiplatform` is a standards-first Kotlin Multiplatform library for WebAuthn and passkey integrations.
+
+The project is not a single SDK. It is a layered set of modules that can be adopted separately for:
+
+- typed protocol models
+- strict ceremony validation
+- crypto and attestation verification
+- JVM server orchestration
+- Android and iOS passkey clients
+- transport and sample integrations
+
+## North Star
+
+The canonical project goal is in [`docs/ai/STEERING.md`](../ai/STEERING.md): build the most robust and standards-first WebAuthn Kotlin Multiplatform library, and ship it as a trustworthy public open-source project.
+
+Important consequences:
+
+- standards alignment is more important than convenience wrappers
+- security-critical validation paths must not regress
+- KMP layering boundaries are intentional, especially around `webauthn-model`, `webauthn-core`, and `webauthn-client-core`
+- documentation, compatibility, and release hygiene matter because the public release posture is active
+
+## Who This Is For
+
+- Kotlin teams building passwordless or passkey-backed sign-in flows
+- teams that want to share logic across JVM backend, Android, and iOS
+- teams that prefer typed APIs and modular adoption instead of a single all-in-one SDK
+
+## Fast Orientation Path
+
+1. Read [`module-map.md`](./module-map.md) for the layer model and published surface.
+2. Read [`client-stack.md`](./client-stack.md) or [`server-stack.md`](./server-stack.md) depending on your integration direction.
+3. Read [`samples-and-demos.md`](./samples-and-demos.md) for runnable examples.
+4. Read [`quality-and-release.md`](./quality-and-release.md) before making changes that affect public modules.
+
+## Canonical Source Anchors
+
+- Root product overview: [`README.md`](../../README.md)
+- Architecture overview: [`docs/architecture.md`](../architecture.md)
+- Implementation status: [`docs/IMPLEMENTATION_STATUS.md`](../IMPLEMENTATION_STATUS.md)
+- Roadmap: [`docs/ROADMAP.md`](../ROADMAP.md)
+- Contribution workflow: [`CONTRIBUTING.md`](../../CONTRIBUTING.md)

--- a/docs/wiki/quality-and-release.md
+++ b/docs/wiki/quality-and-release.md
@@ -1,0 +1,58 @@
+# Quality And Release
+
+Last reviewed: 2026-04-06
+
+The repo treats public release posture as active. Even small changes should be checked against compatibility, documentation trace, and quality-gate expectations.
+
+## Default Quality Gates
+
+Run the smallest matching checks first:
+
+```bash
+tools/agent/quality-gate.sh --mode fast --scope changed --block false
+tools/agent/quality-gate.sh --mode strict --scope changed --block false
+```
+
+These are the standard advisory gates for local work and pre-PR validation.
+
+## When To Run Extra Checks
+
+- Run `./gradlew apiCheck --stacktrace` when a BCV-covered published API changes.
+- Run `./gradlew publishToMavenLocal --stacktrace` when publishing coordinates, metadata, or release wiring change.
+- Escalate to broader checks only when the change is cross-cutting, risky, or explicitly requested.
+
+## Release-Train Model
+
+- Published artifacts move together on one coordinated version.
+- The BOM is the alignment entry point for consumers.
+- Samples, `platform:constraints`, and `build-logic` are not part of the published artifact surface.
+- Public-facing docs need to stay current when public API or integration paths change.
+
+## Documentation Trace Rules
+
+The steering doc requires synchronized docs updates when:
+
+- a BCV-covered published module API changes
+- public integration paths change
+- security-facing workflows or policy change
+- publishing workflow or release posture changes
+
+In practice that usually means touching the relevant module `README.md`, and sometimes the root [`README.md`](../../README.md) plus [`docs/architecture.md`](../architecture.md).
+
+## Decision Ladder
+
+The preferred order is:
+
+1. read the changed files
+2. read nearby impacted docs/tests/build files
+3. run fast changed-scope gate
+4. run strict changed-scope gate
+5. run `apiCheck` if public API changed
+6. run `publishToMavenLocal` if publishing/build metadata changed
+
+## Canonical Source Anchors
+
+- Steering and done criteria: [`docs/ai/STEERING.md`](../ai/STEERING.md)
+- Contribution workflow: [`CONTRIBUTING.md`](../../CONTRIBUTING.md)
+- Maven Central guide: [`docs/MAVEN_CENTRAL.md`](../MAVEN_CENTRAL.md)
+- Public launch checklist: [`docs/PUBLIC_LAUNCH_CHECKLIST.md`](../PUBLIC_LAUNCH_CHECKLIST.md)

--- a/docs/wiki/samples-and-demos.md
+++ b/docs/wiki/samples-and-demos.md
@@ -1,0 +1,44 @@
+# Samples And Demos
+
+Last reviewed: 2026-04-06
+
+The sample apps are reference integrations, not published library modules. They exist to prove end-to-end flows, show intended usage, and shorten onboarding.
+
+## Main Reference Set
+
+- `samples/backend-ktor`: demo backend exposing the default `/webauthn/*` contract plus health and associated-domain endpoints
+- `samples/compose-passkey`: shared Compose Multiplatform sample module demonstrating register, sign-in, capability checks, debug logs, and PRF crypto demo flow
+- `samples/compose-passkey-android`: Android host app for the shared Compose sample
+- `samples/compose-passkey-ios`: iOS host app for the shared Compose sample
+- `samples/passkey-cli`: experimental macOS-first native-authenticator CLI proof of concept
+- `samples/android-passkey` and `samples/ios-passkey`: platform-specific sample apps outside the Compose path
+
+## Default Demo Contract
+
+The sample backend exposes:
+
+- `POST /webauthn/registration/start`
+- `POST /webauthn/registration/finish`
+- `POST /webauthn/authentication/start`
+- `POST /webauthn/authentication/finish`
+
+This contract is the default assumed by `webauthn-network-ktor-client` and the Compose sample.
+
+## Why These Matter
+
+- They are the fastest way to understand the intended client/server wiring.
+- They provide an end-to-end test bed for Android and iOS passkey work.
+- They demonstrate associated-domain and local-dev environment setup details that do not belong in the library core.
+
+## Practical Notes
+
+- Physical-device flows are easiest through the `samples/backend-ktor/start-server.sh` helper, which aligns local properties with an ngrok domain.
+- The Compose sample includes structured debug logging and a PRF demo, making it the highest-signal reference app for current client work.
+- Android runtime success still depends on device/provider prerequisites such as Play services, screen lock, and a passkey-capable account.
+
+## Canonical Source Anchors
+
+- Sample overview in root docs: [`README.md`](../../README.md)
+- Backend sample doc: [`samples/backend-ktor/README.md`](../../samples/backend-ktor/README.md)
+- Compose sample doc: [`samples/compose-passkey/README.md`](../../samples/compose-passkey/README.md)
+- Desktop/CLI notes: [`docs/DESKTOP_CLI_STRATEGY.md`](../DESKTOP_CLI_STRATEGY.md)

--- a/docs/wiki/server-stack.md
+++ b/docs/wiki/server-stack.md
@@ -2,7 +2,7 @@
 
 Last reviewed: 2026-04-06
 
-The server side centers on standards-first ceremony validation and JVM-focused orchestration.
+The server-side stack centers on standards-first ceremony validation and JVM-focused orchestration.
 
 ## Core Shape
 

--- a/docs/wiki/server-stack.md
+++ b/docs/wiki/server-stack.md
@@ -1,0 +1,54 @@
+# Server Stack
+
+Last reviewed: 2026-04-06
+
+The server side centers on standards-first ceremony validation and JVM-focused orchestration.
+
+## Core Shape
+
+- `webauthn-core` validates ceremony semantics and authenticator data rules.
+- `webauthn-crypto-api` defines the crypto and attestation contracts the rest of the stack depends on.
+- `webauthn-server-jvm-crypto` provides the JVM crypto implementation, with Signum-first policy and attestation verifiers.
+- `webauthn-server-core-jvm` provides framework-agnostic registration and authentication services.
+- `webauthn-server-ktor` adds thin Ktor route adapters.
+- `webauthn-server-store-exposed` adds Exposed-backed persistence implementations.
+- `webauthn-attestation-mds` is an optional trust-source module for FIDO Metadata Service data.
+
+## Practical Flow
+
+1. The server starts a registration or authentication ceremony and returns options.
+2. The client performs the platform passkey flow.
+3. The server finish path validates challenge, origin, type, RP ID hash, flags, counters, and related ceremony invariants.
+4. Crypto and attestation verification run through the configured verifier contracts.
+5. Persistence modules store challenge and credential state when needed.
+
+Validation and trust decisions remain server responsibilities, even when the client libraries are shared with the backend stack.
+
+## Important Boundaries
+
+- Core ceremony services stay framework-agnostic in `webauthn-server-core-jvm`.
+- Ktor integration is intentionally thin.
+- Persistence is modular rather than baked into the core service layer.
+- Optional trust sources should not force themselves into simpler deployments.
+
+## Current Status Snapshot
+
+From the current status and roadmap docs:
+
+- validation and server ceremony paths are among the most mature parts of the repo
+- JVM crypto and attestation verification are implemented with continuing vector hardening
+- Exposed-backed stores exist and already have contract coverage
+- additional attestation matrix depth and broader operational hardening remain active work
+
+## Where To Go Next
+
+- For the shared and platform client side, read [`client-stack.md`](./client-stack.md).
+- For the sample backend contract, read [`samples-and-demos.md`](./samples-and-demos.md).
+- For release and compatibility implications of server changes, read [`quality-and-release.md`](./quality-and-release.md).
+
+## Canonical Source Anchors
+
+- Root server adoption section: [`README.md`](../../README.md)
+- Architecture doc: [`docs/architecture.md`](../architecture.md)
+- Dependency policy: [`docs/dependency-decisions.md`](../dependency-decisions.md)
+- Sample backend: [`samples/backend-ktor/README.md`](../../samples/backend-ktor/README.md)

--- a/docs/wiki/specs-and-sources.md
+++ b/docs/wiki/specs-and-sources.md
@@ -1,0 +1,49 @@
+# Specs And Sources
+
+Last reviewed: 2026-04-06
+
+This project is standards-first. The wiki should summarize and connect information, but normative behavior comes from the standards and the repository's canonical implementation docs.
+
+## Normative Standards
+
+Per repository steering, the primary standards set is:
+
+- W3C WebAuthn Level 3
+- RFC 4648
+- RFC 8949
+- RFC 9052 and RFC 9053
+
+These govern behavior and public API intent more strongly than convenience or ecosystem precedent.
+
+## High-Value Repository Sources
+
+- [`README.md`](../../README.md): product-level overview, module catalog, install guidance, sample entry points
+- [`docs/architecture.md`](../architecture.md): layer boundaries and dependency shape
+- [`docs/IMPLEMENTATION_STATUS.md`](../IMPLEMENTATION_STATUS.md): current maturity snapshot by module
+- [`docs/ROADMAP.md`](../ROADMAP.md): next-phase priorities and definitions of done
+- [`docs/dependency-decisions.md`](../dependency-decisions.md): crypto/backend dependency policy and rationale
+- [`docs/ai/STEERING.md`](../ai/STEERING.md): canonical contributor and agent policy
+- [`spec-cache/README.md`](../../spec-cache/README.md): local spec cache index
+- [`spec-notes/webauthn-l3-validation-map.md`](../../spec-notes/webauthn-l3-validation-map.md): trace of implemented validation rules
+
+## How The Wiki Should Use Sources
+
+- Treat source docs as canonical and the wiki as synthesis.
+- Prefer linking to module and sample `README.md` files rather than restating full API usage.
+- Use exact dates when summarizing status from roadmap or implementation docs.
+- When a source appears stale or contradictory, note the tension and update the wiki only after checking the authoritative file.
+
+## Suggested Ingest Pattern For Future Updates
+
+When a substantial repo change lands:
+
+1. read the changed canonical docs and nearby module/sample READMEs
+2. update the matching wiki page summaries
+3. refresh [`index.md`](./index.md) if the page catalog changed
+4. append a dated note to [`log.md`](./log.md)
+
+## Related Wiki Pages
+
+- [`project-overview.md`](./project-overview.md)
+- [`module-map.md`](./module-map.md)
+- [`quality-and-release.md`](./quality-and-release.md)

--- a/docs/wiki/status-and-roadmap.md
+++ b/docs/wiki/status-and-roadmap.md
@@ -1,0 +1,42 @@
+# Status And Roadmap
+
+Last reviewed: 2026-04-06
+
+This page compresses the current project maturity into a quick scan. For exact wording and deeper detail, follow the canonical source links below.
+
+## Current Snapshot
+
+- Core protocol model and validation baselines are implemented and heavily tested.
+- JVM server ceremony flow is implemented and comparatively mature.
+- Client-side shared orchestration plus Android and iOS bridges are in place and usable.
+- Publication, compatibility baselines, and Maven Central workflow are active.
+- The project is publicly released but still pre-1.0.
+
+## Maturity Pattern
+
+- Production-leaning: core validation paths and `webauthn-network-ktor-client`
+- Beta: most server, client, crypto, and adapter modules
+- Scaffold: not the dominant status right now; most major module families already exceed scaffold level
+
+## Near-Term Priorities
+
+- continue attestation trust-path hardening, especially remaining matrix depth
+- keep assertion and interoperability vector coverage strong while dependencies evolve
+- keep outreach-facing and adoption-facing docs aligned with sample and release evolution
+
+## How To Read Change Pressure
+
+If work touches any of the following, expect higher review and documentation burden:
+
+- standards-facing validation behavior
+- crypto or attestation verification
+- public module APIs
+- release and publishing workflow
+- client/server integration paths shown in root docs and samples
+
+## Canonical Source Anchors
+
+- Full implementation status: [`docs/IMPLEMENTATION_STATUS.md`](../IMPLEMENTATION_STATUS.md)
+- Roadmap: [`docs/ROADMAP.md`](../ROADMAP.md)
+- Validation trace: [`spec-notes/webauthn-l3-validation-map.md`](../../spec-notes/webauthn-l3-validation-map.md)
+- Steering done criteria: [`docs/ai/STEERING.md`](../ai/STEERING.md)


### PR DESCRIPTION
## Summary
- add a repo-native `docs/wiki/` project wiki adapted from the LLM-wiki pattern
- seed the wiki with an index, maintenance schema, change log, and cross-linked pages for architecture, client/server stacks, samples, quality, status, and sources
- link the new wiki from the root README for discoverability

## Why
The repository already has strong canonical docs, but they are spread across root docs, module READMEs, status docs, and sample docs. This PR adds a synthesized navigation layer for contributors and agents without replacing those source documents.

## Review result
I reviewed the new docs before publishing and did not find actionable issues in scope.

## Validation
- `tools/agent/quality-gate.sh --mode fast --scope changed --block false`
- `tools/agent/quality-gate.sh --mode strict --scope changed --block false`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new project wiki to provide centralized guidance on project architecture, module organization, client and server stack design, quality expectations, release process, samples and demos, standards adherence, and roadmap status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->