### PR TITLE
Align KMP iOS targets with Signum Apple X64 removal

### DIFF
--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -2,7 +2,7 @@
 
 This document tracks what is implemented today and the current maturity by module.
 
-Last updated: 2026-04-03
+Last updated: 2026-04-15
 
 ## Status Legend
 
@@ -13,6 +13,7 @@ Last updated: 2026-04-03
 ## Overall Snapshot
 
 - Protocol model and core validation baselines are implemented with strict negative-path tests.
+- Apple X64 target alignment update (2026-04-15): removed `iosX64()` targets across core/client/network/sample modules to align with upstream Signum 3.21.0 / Supreme 0.13.0 dropping Apple X64 variants; active iOS targets remain `iosArm64` and `iosSimulatorArm64`.
 - Conformance hardening update (2026-04-03): added RFC-style golden coverage for base64url/CBOR/authenticator data parsing, offline registration and assertion ceremony fixtures, JVM-only differential checks against WebAuthn4J and Yubico server behavior, and client JSON interop checks for Yubico-generated browser payloads; serialization now rejects trailing `authenticatorData` bytes and malformed extension CBOR deterministically before ceremony verification.
 - PR #92 review follow-up (2026-03-29): reverted low-value one-off helper extractions in client adapters, hardened `InMemoryCredentialStore` concurrency (`computeIfAbsent` + concurrent key set), and reused precomputed credential-id encoding in Exposed insert path; no public API contract change intended.
 - Vertical chaining + callable-reference style consistency pass (2026-03-29): applied readability-only formatting and `::` adoption across client/network/serialization/server/store modules and related tests, with minimal crypto-internal touch-ups; no runtime/API behavior changes intended.

--- a/samples/ios-passkey/build.gradle.kts
+++ b/samples/ios-passkey/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
 }
 
 kotlin {
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/webauthn-cbor-core/README.md
+++ b/webauthn-cbor-core/README.md
@@ -24,6 +24,11 @@ flowchart LR
 - APIs are public and intended for reuse by parser modules.
 - Semantics remain strict by design (minimal-encoding rejection and overflow-safe bounds checks).
 
+## iOS targets
+
+- Published Apple targets are `iosArm64` and `iosSimulatorArm64`.
+- `iosX64` support was removed to align with upstream dependency artifacts and current CI target compatibility.
+
 ## Status
 
 Beta, shared CBOR parser primitive module.

--- a/webauthn-cbor-core/api/webauthn-cbor-core.klib.api
+++ b/webauthn-cbor-core/api/webauthn-cbor-core.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64]
+// Targets: [iosArm64, iosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/webauthn-cbor-core/build.gradle.kts
+++ b/webauthn-cbor-core/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 
 kotlin {
     jvm()
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/webauthn-client-compose/README.md
+++ b/webauthn-client-compose/README.md
@@ -92,6 +92,11 @@ Usage notes:
 - Does not replace backend ceremony verification/policy decisions.
 - Does not own networking retry/session policy.
 
+## iOS targets
+
+- Published Apple targets are `iosArm64` and `iosSimulatorArm64`.
+- `iosX64` support was removed to align with upstream dependency artifacts and current CI target compatibility.
+
 ## Status
 
 Beta, stable helper layer for Compose-first passkey flows.

--- a/webauthn-client-compose/api/webauthn-client-compose.klib.api
+++ b/webauthn-client-compose/api/webauthn-client-compose.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64]
+// Targets: [iosArm64, iosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/webauthn-client-compose/build.gradle.kts
+++ b/webauthn-client-compose/build.gradle.kts
@@ -11,7 +11,6 @@ kotlin {
         compileSdk = 36
         minSdk = 26
     }
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/webauthn-client-core/README.md
+++ b/webauthn-client-core/README.md
@@ -125,6 +125,11 @@ Usage notes:
 - No backend validation/crypto behavior.
 - Platform bridge implementation is provided by target-specific modules.
 
+## iOS targets
+
+- Published Apple targets are `iosArm64` and `iosSimulatorArm64`.
+- `iosX64` support was removed to align with upstream dependency artifacts and current CI target compatibility.
+
 ## Status
 
 Beta, shared orchestration layer for client passkey ceremonies.

--- a/webauthn-client-core/api/webauthn-client-core.klib.api
+++ b/webauthn-client-core/api/webauthn-client-core.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64]
+// Targets: [iosArm64, iosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/webauthn-client-core/build.gradle.kts
+++ b/webauthn-client-core/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 
 kotlin {
     jvm()
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/webauthn-client-ios/README.md
+++ b/webauthn-client-ios/README.md
@@ -47,6 +47,11 @@ flowchart LR
 - On iOS 18+ runtime APIs, assertion PRF input supports shared `prf.eval` and per-credential `prf.evalByCredential`; malformed keys are rejected as invalid options.
 - `attestation` is forwarded as requested by callers; this module does not silently coerce `direct` to `none`. Apple platform behavior still determines the concrete attestation object returned at runtime.
 
+## iOS targets
+
+- Published Apple targets are `iosArm64` and `iosSimulatorArm64`.
+- `iosX64` support was removed to align with upstream dependency artifacts and current CI target compatibility.
+
 ## Status
 
 Beta, thin iOS bridge on top of shared client orchestration.

--- a/webauthn-client-ios/api/webauthn-client-ios.klib.api
+++ b/webauthn-client-ios/api/webauthn-client-ios.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64]
+// Targets: [iosArm64, iosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/webauthn-client-ios/build.gradle.kts
+++ b/webauthn-client-ios/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 }
 
 kotlin {
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/webauthn-client-json-core/README.md
+++ b/webauthn-client-json-core/README.md
@@ -38,6 +38,11 @@ flowchart LR
 - JSON entrypoints use the same validated DTO mapping surface as the typed client APIs; malformed request JSON still fails as `InvalidOptions`.
 - Keep mapper and model versions aligned with BOM to avoid shape drift.
 
+## iOS targets
+
+- Published Apple targets are `iosArm64` and `iosSimulatorArm64`.
+- `iosX64` support was removed to align with upstream dependency artifacts and current CI target compatibility.
+
 ## Status
 
 Beta, optional JSON interop layer.

--- a/webauthn-client-json-core/api/webauthn-client-json-core.klib.api
+++ b/webauthn-client-json-core/api/webauthn-client-json-core.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64]
+// Targets: [iosArm64, iosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/webauthn-client-json-core/build.gradle.kts
+++ b/webauthn-client-json-core/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 
 kotlin {
     jvm()
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/webauthn-client-prf-crypto/README.md
+++ b/webauthn-client-prf-crypto/README.md
@@ -102,6 +102,11 @@ Important usage notes:
 - `@ExperimentalWebAuthnL3Api` applies.
 - No key rotation, secure enclave policy, or salt migration framework.
 
+## iOS targets
+
+- Published Apple targets are `iosArm64` and `iosSimulatorArm64`.
+- `iosX64` support was removed to align with upstream dependency artifacts and current CI target compatibility.
+
 ## Status
 
 Beta, Signum-backed PRF crypto utility layer.

--- a/webauthn-client-prf-crypto/api/webauthn-client-prf-crypto.klib.api
+++ b/webauthn-client-prf-crypto/api/webauthn-client-prf-crypto.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64]
+// Targets: [iosArm64, iosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/webauthn-client-prf-crypto/build.gradle.kts
+++ b/webauthn-client-prf-crypto/build.gradle.kts
@@ -11,7 +11,6 @@ kotlin {
         minSdk = 30
     }
     jvm()
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/webauthn-core/README.md
+++ b/webauthn-core/README.md
@@ -99,6 +99,11 @@ val result = prfOnly.validateAuthenticationExtensions(inputs, outputs)
 - No JSON/CBOR parsing or transport DTO mapping.
 - No crypto backend execution (delegated to `webauthn-crypto-api` implementations).
 
+## iOS targets
+
+- Published Apple targets are `iosArm64` and `iosSimulatorArm64`.
+- `iosX64` support was removed to align with upstream dependency artifacts and current CI target compatibility.
+
 ## Status
 
 Production-leaning validation engine.

--- a/webauthn-core/api/webauthn-core.klib.api
+++ b/webauthn-core/api/webauthn-core.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64]
+// Targets: [iosArm64, iosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/webauthn-core/build.gradle.kts
+++ b/webauthn-core/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 
 kotlin {
     jvm()
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/webauthn-model/README.md
+++ b/webauthn-model/README.md
@@ -79,6 +79,11 @@ API notes:
 - No JSON/CBOR mapping by itself (use `webauthn-serialization-kotlinx` when needed).
 - No RP hash/signature/attestation verification logic.
 
+## iOS targets
+
+- Published Apple targets are `iosArm64` and `iosSimulatorArm64`.
+- `iosX64` support was removed to align with upstream dependency artifacts and current CI target compatibility.
+
 ## Status
 
 Production-leaning foundational contract module.

--- a/webauthn-model/api/webauthn-model.klib.api
+++ b/webauthn-model/api/webauthn-model.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64]
+// Targets: [iosArm64, iosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/webauthn-model/build.gradle.kts
+++ b/webauthn-model/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 
 kotlin {
     jvm()
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/webauthn-network-ktor-client/README.md
+++ b/webauthn-network-ktor-client/README.md
@@ -44,6 +44,11 @@ flowchart LR
 - Retry, timeout, auth headers, and observability remain caller-owned through the provided `HttpClient`.
 - `KtorOriginMetadataProvider` fails closed (returns empty related origins) on transport/parse failures, but coroutine cancellation is always rethrown.
 
+## iOS targets
+
+- Published Apple targets are `iosArm64` and `iosSimulatorArm64`.
+- `iosX64` support was removed to align with upstream dependency artifacts and current CI target compatibility.
+
 ## Status
 
 Production-leaning transport helper with explicit backend contract support.

--- a/webauthn-network-ktor-client/api/webauthn-network-ktor-client.klib.api
+++ b/webauthn-network-ktor-client/api/webauthn-network-ktor-client.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64]
+// Targets: [iosArm64, iosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/webauthn-network-ktor-client/build.gradle.kts
+++ b/webauthn-network-ktor-client/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 
 kotlin {
     jvm()
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/webauthn-runtime-core/README.md
+++ b/webauthn-runtime-core/README.md
@@ -57,6 +57,11 @@ This module provides coroutine-safe alternatives that rethrow `CancellationExcep
 - This module does not define domain error models.
 - It only standardizes coroutine/failure boundary mechanics.
 
+## iOS targets
+
+- Published Apple targets are `iosArm64` and `iosSimulatorArm64`.
+- `iosX64` support was removed to align with upstream dependency artifacts and current CI target compatibility.
+
 ## Status
 
 Beta, shared runtime helper module.

--- a/webauthn-runtime-core/api/webauthn-runtime-core.klib.api
+++ b/webauthn-runtime-core/api/webauthn-runtime-core.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64]
+// Targets: [iosArm64, iosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/webauthn-runtime-core/build.gradle.kts
+++ b/webauthn-runtime-core/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 
 kotlin {
     jvm()
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/webauthn-serialization-kotlinx/README.md
+++ b/webauthn-serialization-kotlinx/README.md
@@ -42,6 +42,11 @@ flowchart LR
 - `allowCredentials: null` is accepted only as a compatibility decode shim and normalized to an empty list; canonical JSON should still treat `allowCredentials` as an optional sequence (not `null`).
 - Keep model and mapper versions aligned (BOM recommended).
 
+## iOS targets
+
+- Published Apple targets are `iosArm64` and `iosSimulatorArm64`.
+- `iosX64` support was removed to align with upstream dependency artifacts and current CI target compatibility.
+
 ## Status
 
 Beta, strict mapper validation with CBOR/COSE handling.

--- a/webauthn-serialization-kotlinx/api/webauthn-serialization-kotlinx.klib.api
+++ b/webauthn-serialization-kotlinx/api/webauthn-serialization-kotlinx.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64]
+// Targets: [iosArm64, iosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/webauthn-serialization-kotlinx/build.gradle.kts
+++ b/webauthn-serialization-kotlinx/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 
 kotlin {
     jvm()
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 


### PR DESCRIPTION
## Summary
- remove `iosX64()` from all affected KMP modules and iOS sample targets
- update KLIB API baselines to reflect Apple targets `[iosArm64, iosSimulatorArm64]`
- add module README iOS target notes and implementation status trace update required by repo policy

## Why
Recent Signum releases dropped Apple X64 artifacts. Renovate PRs updating to:
- `at.asitplus.signum:supreme:0.13.0`
- `at.asitplus.signum:indispensable:3.21.0`

started failing CI because our build still requested `ios_x64` variants.

## Validation
- `tools/agent/quality-gate.sh --mode strict --scope changed --block false`
- `./gradlew apiCheck --stacktrace`
- `./gradlew publishToMavenLocal --stacktrace`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation across modules to clarify supported iOS target architectures (ARM64 and ARM64 simulator only).

* **Chores**
  * Removed x64 iOS simulator target from build configurations to align with current platform support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->