### PR TITLE
fix: raise Android compileSdk to 37

### DIFF
--- a/build-logic/src/main/kotlin/webauthn.android.application.gradle.kts
+++ b/build-logic/src/main/kotlin/webauthn.android.application.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/build-logic/src/main/kotlin/webauthn.android.library.gradle.kts
+++ b/build-logic/src/main/kotlin/webauthn.android.library.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26

--- a/client/webauthn-client-compose/build.gradle.kts
+++ b/client/webauthn-client-compose/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 kotlin {
     android {
         namespace = "dev.webauthn.client.compose"
-        compileSdk = 36
+        compileSdk = 37
         minSdk = 26
     }
     iosArm64()

--- a/client/webauthn-client-prf-crypto/build.gradle.kts
+++ b/client/webauthn-client-prf-crypto/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 kotlin {
     android {
         namespace = "dev.webauthn.client.prf"
-        compileSdk = 36
+        compileSdk = 37
         minSdk = 30
     }
     jvm()

--- a/sample/compose-passkey/build.gradle.kts
+++ b/sample/compose-passkey/build.gradle.kts
@@ -12,7 +12,7 @@ kotlin {
 
     android {
         namespace = "dev.webauthn.samples.composepasskey"
-        compileSdk = 36
+        compileSdk = 37
         minSdk = 30
     }
 


### PR DESCRIPTION
fix: raise Android compileSdk to 37

This split PR updates the Android compile SDK to 37 so the androidx.core 1.19.0 dependency bump can pass CI without mixing build-system changes into the Renovate update.

Why:

- androidx.core/core-ktx 1.19.0 requires compileSdk 37+
- the repo had several Android targets still pinned to compileSdk 36

Validation:

- tools/agent/quality-gate.sh --mode fast --scope changed --block false
- tools/agent/quality-gate.sh --mode strict --scope changed --block false
