### PR TITLE
build(sample): prepare Android hosts for target SDK 37

### DIFF
--- a/build-logic/src/main/kotlin/webauthn.android.application.gradle.kts
+++ b/build-logic/src/main/kotlin/webauthn.android.application.gradle.kts
@@ -7,7 +7,7 @@ android {
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 36
+        targetSdk = 37
         versionCode = 1
         versionName = "0.1.0"
     }

--- a/sample/compose-passkey-android/build.gradle.kts
+++ b/sample/compose-passkey-android/build.gradle.kts
@@ -32,6 +32,16 @@ val demoRpId = demoConfigValue(
     defaultValue = "localhost",
 )
 
+val demoEndpoint = demoConfigValue(
+    envName = "WEBAUTHN_DEMO_ENDPOINT",
+    defaultValue = "http://127.0.0.1:8080",
+)
+
+val requestLocalNetworkPermission = demoConfigValue(
+    envName = "WEBAUTHN_DEMO_REQUEST_LOCAL_NETWORK_PERMISSION",
+    defaultValue = "false",
+).toBooleanStrictOrNull() ?: false
+
 android {
     namespace = "dev.webauthn.samples.composepasskey.android"
 
@@ -40,9 +50,15 @@ android {
         minSdk = 30
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         manifestPlaceholders["SERVER_HOST"] = demoRpId
+        val escapedDemoEndpoint = demoEndpoint
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+        buildConfigField("String", "WEBAUTHN_DEMO_ENDPOINT", "\"$escapedDemoEndpoint\"")
+        buildConfigField("Boolean", "WEBAUTHN_DEMO_REQUEST_LOCAL_NETWORK_PERMISSION", "$requestLocalNetworkPermission")
     }
 
     buildFeatures {
+        buildConfig = true
         compose = true
     }
 }

--- a/sample/compose-passkey-android/src/main/AndroidManifest.xml
+++ b/sample/compose-passkey-android/src/main/AndroidManifest.xml
@@ -2,13 +2,13 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
 
     <application
         android:allowBackup="true"
         android:label="Compose Passkey Sample"
         android:networkSecurityConfig="@xml/network_security_config"
         android:theme="@android:style/Theme.Material.Light.NoActionBar"
-        android:usesCleartextTraffic="true"
         android:supportsRtl="true">
         <activity
             android:name=".MainActivity"

--- a/sample/compose-passkey-android/src/main/kotlin/dev/webauthn/samples/composepasskey/android/MainActivity.kt
+++ b/sample/compose-passkey-android/src/main/kotlin/dev/webauthn/samples/composepasskey/android/MainActivity.kt
@@ -1,15 +1,33 @@
 package dev.webauthn.samples.composepasskey.android
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import dev.webauthn.samples.composepasskey.app.App
 
+private const val ANDROID_17_API_LEVEL = 37
+private const val LOCAL_NETWORK_PERMISSION_REQUEST_CODE = ANDROID_17_API_LEVEL
+
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        requestLocalNetworkPermissionIfNeeded()
         setContent {
             App()
         }
+    }
+
+    private fun requestLocalNetworkPermissionIfNeeded() {
+        if (Build.VERSION.SDK_INT < ANDROID_17_API_LEVEL) return
+        if (!BuildConfig.WEBAUTHN_DEMO_REQUEST_LOCAL_NETWORK_PERMISSION) return
+        if (checkSelfPermission(Manifest.permission.ACCESS_LOCAL_NETWORK) == PackageManager.PERMISSION_GRANTED) return
+
+        requestPermissions(
+            arrayOf(Manifest.permission.ACCESS_LOCAL_NETWORK),
+            LOCAL_NETWORK_PERMISSION_REQUEST_CODE,
+        )
     }
 }

--- a/sample/compose-passkey/READINESS_CHECKLIST.md
+++ b/sample/compose-passkey/READINESS_CHECKLIST.md
@@ -51,6 +51,9 @@ Prerequisites:
 - build-time endpoint configured via `WEBAUTHN_DEMO_ENDPOINT` for your target
   - emulator: `http://10.0.2.2:8080`
   - physical device: `http://<laptop-lan-ip>:8080`
+- Android 17 / target SDK 37 local-network permission granted when using a
+  private-network endpoint from an emulator or physical device; build with
+  `WEBAUTHN_DEMO_REQUEST_LOCAL_NETWORK_PERMISSION=true`
 
 Run:
 

--- a/sample/compose-passkey/README.md
+++ b/sample/compose-passkey/README.md
@@ -21,6 +21,7 @@ Build-time config is shared across Android and iOS (not platform-specific). Thes
 - `WEBAUTHN_DEMO_ORIGIN` (default: `https://localhost`)
 - `WEBAUTHN_DEMO_USER_ID` (default: `demo-user-1`)
 - `WEBAUTHN_DEMO_USER_NAME` (default: `demo@local`)
+- Android host only: `WEBAUTHN_DEMO_REQUEST_LOCAL_NETWORK_PERMISSION` (default: `false`)
 
 Examples:
 
@@ -46,10 +47,19 @@ For physical devices, prefer tunnel mode:
 
 This updates root `local.properties` (`WEBAUTHN_DEMO_ENDPOINT`, `WEBAUTHN_DEMO_RP_ID`, `WEBAUTHN_DEMO_ORIGIN`) to match the active ngrok domain.
 
+Android 17 note: the Android host targets SDK 37, so direct private-network endpoints
+such as `10.0.2.2`, `192.168.x.x`, or `172.16-31.x.x` require the platform
+`ACCESS_LOCAL_NETWORK` runtime permission. Set
+`WEBAUTHN_DEMO_REQUEST_LOCAL_NETWORK_PERMISSION=true` when building the sample
+against one of those direct local endpoints. Public HTTPS endpoints and loopback
+defaults do not need the prompt.
+
 2. Build and run sample host app:
 
 ```bash
-WEBAUTHN_DEMO_ENDPOINT=http://10.0.2.2:8080 ./gradlew :sample:compose-passkey-android:installDebug
+WEBAUTHN_DEMO_ENDPOINT=http://10.0.2.2:8080 \
+WEBAUTHN_DEMO_REQUEST_LOCAL_NETWORK_PERMISSION=true \
+./gradlew :sample:compose-passkey-android:installDebug
 ```
 
 3. Optional UI smoke test (emulator/device connected):


### PR DESCRIPTION
## Summary
- target Android application hosts to SDK 37 after the compile SDK bump
- add the Android 17 `ACCESS_LOCAL_NETWORK` declaration and an explicit sample build flag for direct LAN demo endpoints
- remove manifest-wide `usesCleartextTraffic` from the Compose Android host and rely on network security config instead
- document Android 17 local-network setup in the Compose passkey README and readiness checklist

## Why
Android 17 blocks local-network traffic by default for apps targeting SDK 37 unless they declare and request `ACCESS_LOCAL_NETWORK`. The sample only needs that prompt for direct local demo endpoints such as `10.0.2.2` or a laptop LAN IP, so the PR uses an explicit `WEBAUTHN_DEMO_REQUEST_LOCAL_NETWORK_PERMISSION=true` build flag instead of endpoint parsing or a new permission library.

## Validation
- `./gradlew :sample:compose-passkey-android:lintDebug :sample:compose-passkey-android:assemble :sample:compose-passkey-android:compileDebugAndroidTestKotlin --stacktrace`
- `git diff --check`
- `tools/agent/quality-gate.sh --mode strict --scope changed --block false`

## API / release impact
No published API changes. No Maven publishing preflight required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local network permission support for Android 17+
  * Added configurable demo server endpoint

* **Chores**
  * Updated Android target SDK to 37

* **Documentation**
  * Updated setup instructions for local network permission requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->