### PR TITLE
feat(android): add credential state signaling

### DIFF
--- a/client/webauthn-client-platform/README.md
+++ b/client/webauthn-client-platform/README.md
@@ -6,6 +6,7 @@ Manager; its iOS source set uses AuthenticationServices.
 ## What it provides
 
 - `AndroidPasskeyClient`
+- `AndroidCredentialSignalClient`
 - `AndroidRestoreCredentialClient`
 - `IosPasskeyClient`
 - Android and iOS `PasskeyClient` implementations that return byte-preserving raw registration and authentication responses
@@ -14,6 +15,7 @@ Manager; its iOS source set uses AuthenticationServices.
 - Conditional passkey creation on Android and iOS 18+ through the shared
   `PasskeyCreateOptions.Conditional` contract
 - Android Restore Credentials create/get/clear operations with raw WebAuthn responses
+- Android credential-state signals for server/provider reconciliation
 
 ## When to use
 
@@ -76,6 +78,42 @@ Create the restore credential after a successful sign-in, attempt retrieval duri
 or first launch, and clear it during sign-out. Registration and authentication results stay raw and
 must pass through the same backend trust boundary as ordinary passkey responses.
 
+For provider-side credential reconciliation, send best-effort signals only after the server has
+made the authoritative account-state decision:
+
+<!-- doc-example: id=client-webauthn-client-platform-readme-kotlin-4; owner=source; verify=platform-compile; audience=consumer; source=documentation/examples/src/androidMain/kotlin/dev/webauthn/documentation/examples/AndroidCredentialSignalExample.kt#android-credential-signals -->
+```kotlin
+import android.app.Activity
+import dev.webauthn.client.PasskeyResult
+import dev.webauthn.client.android.AndroidCredentialSignalClient
+import dev.webauthn.model.CredentialId
+import dev.webauthn.model.RpId
+import dev.webauthn.model.UserHandle
+
+suspend fun reconcileCredentialManager(
+    activity: Activity,
+    rpId: RpId,
+    userHandle: UserHandle,
+    acceptedCredentialIds: List<CredentialId>,
+    unknownCredentialId: CredentialId,
+): Triple<PasskeyResult<Unit>, PasskeyResult<Unit>, PasskeyResult<Unit>> {
+    val signals = AndroidCredentialSignalClient(activity.applicationContext)
+    return Triple(
+        signals.signalAllAcceptedCredentialIds(rpId, userHandle, acceptedCredentialIds),
+        signals.signalUnknownCredential(rpId, unknownCredentialId),
+        signals.signalCurrentUserDetails(
+            rpId = rpId,
+            userId = userHandle,
+            name = "demo@example.com",
+            displayName = "Demo User",
+        ),
+    )
+}
+```
+
+Signal success means Credential Manager accepted and dispatched well-formed parameters. It does not
+prove that any provider applied the update, so server-side credential enforcement remains required.
+
 ### iOS
 
 <!-- doc-example: id=client-webauthn-client-platform-readme-kotlin-2; owner=source; verify=platform-compile; audience=consumer; source=documentation/examples/src/iosMain/kotlin/dev/webauthn/documentation/examples/IosClientExample.kt#ios-client -->
@@ -96,9 +134,11 @@ fun iosPasskeyClient(anchorProvider: PasskeyPresentationAnchorProvider): Passkey
 flowchart LR
     UI["Android or iOS UI"] --> CORE["webauthn-client-core raw client"]
     CORE --> ANDROID["AndroidPasskeyClient"]
+    CORE --> SIGNALS["AndroidCredentialSignalClient"]
     CORE --> RESTORE["AndroidRestoreCredentialClient"]
     CORE --> IOS["IosPasskeyClient"]
     ANDROID --> CM["Credential Manager"]
+    SIGNALS --> CM
     RESTORE --> CM
     IOS --> AS["AuthenticationServices"]
 ```
@@ -129,6 +169,14 @@ flowchart LR
 - Restore keys can use the same WebAuthn verification path as passkeys, but the application server
   should record their restore purpose separately from user-managed passkeys so lifecycle and UI
   policy cannot confuse the two credential types.
+- Credential signals are best-effort provider hints. Rate-limit application orchestration: Android
+  documents a maximum of 10 relying-party signal calls in a 120-second window.
+- Credential-signal `origin` values are only for browsers or privileged apps acting on behalf of
+  another application. Ordinary apps should leave `origin` null. On Android 14+, a non-null origin
+  also requires `android.permission.CREDENTIAL_MANAGER_SET_ORIGIN`; otherwise the request fails.
+- Apple exposes analogous reports through Swift `ASCredentialDataManager`, but the type is not
+  available in the current Kotlin/Native AuthenticationServices bindings. The Compose iOS host
+  demonstrates a sample-owned Swift bridge rather than adding an uncallable shared library API.
 - Android maps conditional creation to Credential Manager's `isConditional` and
   `preferImmediatelyAvailableCredentials` flags. A provider may report that no create option is
   available; this is a valid conditional outcome, not permission to show an explicit prompt.

--- a/client/webauthn-client-platform/README.md
+++ b/client/webauthn-client-platform/README.md
@@ -6,6 +6,7 @@ Manager; its iOS source set uses Authentication Services.
 ## What it provides
 
 - `AndroidPasskeyClient`
+- `AndroidCredentialSignalClient`
 - `AndroidRestoreCredentialClient`
 - `IosPasskeyClient`
 - Android and iOS `PasskeyClient` implementations that return byte-preserving raw registration and authentication responses
@@ -14,6 +15,7 @@ Manager; its iOS source set uses Authentication Services.
 - Conditional passkey creation on Android and iOS 18+ through the shared
   `PasskeyCreateOptions.Conditional` contract
 - Android Restore Credentials create/get/clear operations with raw WebAuthn responses
+- Android credential-state signals for server/provider reconciliation
 
 ## When to use
 
@@ -76,6 +78,42 @@ Create the restore credential after a successful sign-in, attempt retrieval duri
 or first launch, and clear it during sign-out. Registration and authentication results stay raw and
 must pass through the same backend trust boundary as ordinary passkey responses.
 
+For provider-side credential reconciliation, send best-effort signals only after the server has
+made the authoritative account-state decision:
+
+<!-- doc-example: id=client-webauthn-client-platform-readme-kotlin-4; owner=source; verify=platform-compile; audience=consumer; source=documentation/examples/src/androidMain/kotlin/dev/webauthn/documentation/examples/AndroidCredentialSignalExample.kt#android-credential-signals -->
+```kotlin
+import android.app.Activity
+import dev.webauthn.client.PasskeyResult
+import dev.webauthn.client.android.AndroidCredentialSignalClient
+import dev.webauthn.model.CredentialId
+import dev.webauthn.model.RpId
+import dev.webauthn.model.UserHandle
+
+suspend fun reconcileCredentialManager(
+    activity: Activity,
+    rpId: RpId,
+    userHandle: UserHandle,
+    acceptedCredentialIds: List<CredentialId>,
+    unknownCredentialId: CredentialId,
+): Triple<PasskeyResult<Unit>, PasskeyResult<Unit>, PasskeyResult<Unit>> {
+    val signals = AndroidCredentialSignalClient(activity.applicationContext)
+    return Triple(
+        signals.signalAllAcceptedCredentialIds(rpId, userHandle, acceptedCredentialIds),
+        signals.signalUnknownCredential(rpId, unknownCredentialId),
+        signals.signalCurrentUserDetails(
+            rpId = rpId,
+            userId = userHandle,
+            name = "demo@example.com",
+            displayName = "Demo User",
+        ),
+    )
+}
+```
+
+Signal success means Credential Manager accepted and dispatched well-formed parameters. It does not
+prove that any provider applied the update, so server-side credential enforcement remains required.
+
 ### iOS
 
 <!-- doc-example: id=client-webauthn-client-platform-readme-kotlin-2; owner=source; verify=platform-compile; audience=consumer; source=documentation/examples/src/iosMain/kotlin/dev/webauthn/documentation/examples/IosClientExample.kt#ios-client -->
@@ -96,9 +134,11 @@ fun iosPasskeyClient(anchorProvider: PasskeyPresentationAnchorProvider): Passkey
 flowchart LR
     UI["Android or iOS UI"] --> CORE["webauthn-client-core raw client"]
     CORE --> ANDROID["AndroidPasskeyClient"]
+    CORE --> SIGNALS["AndroidCredentialSignalClient"]
     CORE --> RESTORE["AndroidRestoreCredentialClient"]
     CORE --> IOS["IosPasskeyClient"]
     ANDROID --> CM["Credential Manager"]
+    SIGNALS --> CM
     RESTORE --> CM
     IOS --> AS["Authentication Services"]
 ```
@@ -129,6 +169,14 @@ flowchart LR
 - Restore keys can use the same WebAuthn verification path as passkeys, but the application server
   should record their restore purpose separately from user-managed passkeys so lifecycle and UI
   policy cannot confuse the two credential types.
+- Credential signals are best-effort provider hints. Rate-limit application orchestration: Android
+  documents a maximum of 10 relying-party signal calls in a 120-second window.
+- Credential-signal `origin` values are only for browsers or privileged apps acting on behalf of
+  another application. Ordinary apps should leave `origin` null. On Android 14+, a non-null origin
+  also requires `android.permission.CREDENTIAL_MANAGER_SET_ORIGIN`; otherwise the request fails.
+- Apple exposes analogous reports through Swift `ASCredentialDataManager`, but the type is not
+  available in the current Kotlin/Native AuthenticationServices bindings. The Compose iOS host
+  demonstrates a sample-owned Swift bridge rather than adding an uncallable shared library API.
 - Android maps conditional creation to Credential Manager's `isConditional` and
   `preferImmediatelyAvailableCredentials` flags. A provider may report that no create option is
   available; this is a valid conditional outcome, not permission to show an explicit prompt.

--- a/client/webauthn-client-platform/src/androidHostTest/kotlin/dev/webauthn/client/android/AndroidCredentialSignalClientTest.kt
+++ b/client/webauthn-client-platform/src/androidHostTest/kotlin/dev/webauthn/client/android/AndroidCredentialSignalClientTest.kt
@@ -1,0 +1,162 @@
+package dev.webauthn.client.android
+
+import android.content.Context
+import androidx.credentials.CredentialManager
+import androidx.credentials.SignalAllAcceptedCredentialIdsRequest
+import androidx.credentials.SignalCredentialStateRequest
+import androidx.credentials.SignalCredentialStateResponse
+import androidx.credentials.SignalCurrentUserDetailsRequest
+import androidx.credentials.SignalUnknownCredentialRequest
+import androidx.credentials.exceptions.publickeycredential.SignalCredentialUnknownException
+import dev.webauthn.client.PasskeyClientError
+import dev.webauthn.client.PasskeyResult
+import dev.webauthn.model.CredentialId
+import dev.webauthn.model.Origin
+import dev.webauthn.model.RpId
+import dev.webauthn.model.UserHandle
+import io.mockk.CapturingSlot
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class AndroidCredentialSignalClientTest {
+    @Test
+    fun signalAllAcceptedCredentialIds_forwards_expected_request_json() = runBlocking {
+        val request = slot<SignalCredentialStateRequest>()
+        val credentialManager = recordingCredentialManager(request)
+        val client = AndroidCredentialSignalClient(
+            context = mockk(relaxed = true),
+            credentialManagerFactory = { credentialManager },
+        )
+
+        val result = client.signalAllAcceptedCredentialIds(
+            rpId = RpId.parseOrThrow("example.com"),
+            userId = UserHandle.fromBytes(byteArrayOf(1, 2, 3)),
+            credentialIds = listOf(
+                CredentialId.fromBytes(byteArrayOf(4, 5, 6)),
+                CredentialId.fromBytes(byteArrayOf(7, 8, 9)),
+            ),
+        )
+
+        assertTrue(result is PasskeyResult.Success)
+        assertTrue(request.captured is SignalAllAcceptedCredentialIdsRequest)
+        val json = JSONObject(request.captured.requestJson)
+        assertEquals("example.com", json.getString("rpId"))
+        assertEquals("AQID", json.getString("userId"))
+        val acceptedIds = json.getJSONArray("allAcceptedCredentialIds")
+        assertEquals("BAUG", acceptedIds.getString(0))
+        assertEquals("BwgJ", acceptedIds.getString(1))
+    }
+
+    @Test
+    fun signalUnknownCredential_forwards_expected_request_json() = runBlocking {
+        val request = slot<SignalCredentialStateRequest>()
+        val credentialManager = recordingCredentialManager(request)
+        val client = AndroidCredentialSignalClient(
+            context = mockk(relaxed = true),
+            credentialManagerFactory = { credentialManager },
+        )
+
+        val result = client.signalUnknownCredential(
+            rpId = RpId.parseOrThrow("example.com"),
+            credentialId = CredentialId.fromBytes(byteArrayOf(4, 5, 6)),
+            origin = Origin.parseOrThrow("https://example.com"),
+        )
+
+        assertTrue(result is PasskeyResult.Success)
+        assertTrue(request.captured is SignalUnknownCredentialRequest)
+        val json = JSONObject(request.captured.requestJson)
+        assertEquals("example.com", json.getString("rpId"))
+        assertEquals("BAUG", json.getString("credentialId"))
+        assertEquals("https://example.com", request.captured.origin)
+    }
+
+    @Test
+    fun signalCurrentUserDetails_forwards_expected_request_json() = runBlocking {
+        val request = slot<SignalCredentialStateRequest>()
+        val credentialManager = recordingCredentialManager(request)
+        val client = AndroidCredentialSignalClient(
+            context = mockk(relaxed = true),
+            credentialManagerFactory = { credentialManager },
+        )
+
+        val result = client.signalCurrentUserDetails(
+            rpId = RpId.parseOrThrow("example.com"),
+            userId = UserHandle.fromBytes(byteArrayOf(1, 2, 3)),
+            name = "demo@example.com",
+            displayName = "Demo User",
+        )
+
+        assertTrue(result is PasskeyResult.Success)
+        assertTrue(request.captured is SignalCurrentUserDetailsRequest)
+        val json = JSONObject(request.captured.requestJson)
+        assertEquals("example.com", json.getString("rpId"))
+        assertEquals("AQID", json.getString("userId"))
+        assertEquals("demo@example.com", json.getString("name"))
+        assertEquals("Demo User", json.getString("displayName"))
+    }
+
+    @Test
+    fun signalUnknownCredential_maps_provider_error_to_platform_failure() = runBlocking {
+        val credentialManager = mockk<CredentialManager>(relaxed = true)
+        val client = AndroidCredentialSignalClient(
+            context = mockk(relaxed = true),
+            credentialManagerFactory = { credentialManager },
+        )
+        coEvery {
+            credentialManager.signalCredentialState(any())
+        } throws SignalCredentialUnknownException("provider unavailable")
+
+        val result = client.signalUnknownCredential(
+            rpId = RpId.parseOrThrow("example.com"),
+            credentialId = CredentialId.fromBytes(byteArrayOf(4, 5, 6)),
+        )
+
+        assertTrue(result is PasskeyResult.Failure)
+        val failure = result as PasskeyResult.Failure
+        assertTrue(failure.error is PasskeyClientError.Platform)
+        assertTrue(failure.error.message.contains("provider unavailable"))
+    }
+
+    @Test
+    fun signalUnknownCredential_maps_security_exception_to_platform_failure() = runBlocking {
+        val credentialManager = mockk<CredentialManager>(relaxed = true)
+        coEvery {
+            credentialManager.signalCredentialState(any())
+        } throws SecurityException("origin permission missing")
+        val client = AndroidCredentialSignalClient(
+            context = mockk(relaxed = true),
+            credentialManagerFactory = { credentialManager },
+        )
+
+        val result = client.signalUnknownCredential(
+            rpId = RpId.parseOrThrow("example.com"),
+            credentialId = CredentialId.fromBytes(byteArrayOf(4, 5, 6)),
+            origin = Origin.parseOrThrow("https://example.com"),
+        )
+
+        val failure = result as PasskeyResult.Failure
+        assertTrue(failure.error is PasskeyClientError.Platform)
+        assertTrue(failure.error.message.contains("origin permission missing"))
+    }
+
+    private fun recordingCredentialManager(
+        request: CapturingSlot<SignalCredentialStateRequest>,
+    ): CredentialManager {
+        val credentialManager = mockk<CredentialManager>(relaxed = true)
+        coEvery {
+            credentialManager.signalCredentialState(capture(request))
+        } returns SignalCredentialStateResponse()
+        return credentialManager
+    }
+}

--- a/client/webauthn-client-platform/src/androidMain/kotlin/dev/webauthn/client/android/AndroidCredentialSignalClient.kt
+++ b/client/webauthn-client-platform/src/androidMain/kotlin/dev/webauthn/client/android/AndroidCredentialSignalClient.kt
@@ -1,0 +1,138 @@
+package dev.webauthn.client.android
+
+import android.content.Context
+import androidx.credentials.CredentialManager
+import androidx.credentials.SignalAllAcceptedCredentialIdsRequest
+import androidx.credentials.SignalCredentialStateRequest
+import androidx.credentials.SignalCurrentUserDetailsRequest
+import androidx.credentials.SignalUnknownCredentialRequest
+import androidx.credentials.exceptions.publickeycredential.SignalCredentialStateException
+import dev.webauthn.client.PasskeyClientError
+import dev.webauthn.client.PasskeyResult
+import dev.webauthn.model.CredentialId
+import dev.webauthn.model.Origin
+import dev.webauthn.model.RpId
+import dev.webauthn.model.UserHandle
+import dev.webauthn.runtime.suspendCatchingNonCancellation
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Android Credential Manager Signal API client for provider-side passkey consistency hints.
+ *
+ * Signal requests do not show UI. Success means Credential Manager accepted and dispatched the
+ * signal to enabled providers; it does not prove that a provider applied the update.
+ */
+public class AndroidCredentialSignalClient(
+    private val context: Context,
+    private val credentialManagerFactory: (Context) -> CredentialManager = CredentialManager::create,
+) {
+    /**
+     * Signals the complete set of credential IDs accepted for the given user.
+     *
+     * [origin] is only for browsers or privileged apps acting for another application. Ordinary
+     * apps must leave it `null`; on Android 14+ a non-null value also requires
+     * `android.permission.CREDENTIAL_MANAGER_SET_ORIGIN`.
+     */
+    public suspend fun signalAllAcceptedCredentialIds(
+        rpId: RpId,
+        userId: UserHandle,
+        credentialIds: List<CredentialId>,
+        origin: Origin? = null,
+    ): PasskeyResult<Unit> {
+        return signalCredentialState(
+            SignalAllAcceptedCredentialIdsRequest(
+                requestJson = JSONObject()
+                    .put(RP_ID_KEY, rpId.value)
+                    .put(USER_ID_KEY, userId.value.encoded())
+                    .put(
+                        ACCEPTED_CREDENTIAL_IDS_KEY,
+                        JSONArray(credentialIds.map { it.value.encoded() }),
+                    )
+                    .toString(),
+                origin = origin?.value,
+            ),
+        )
+    }
+
+    /**
+     * Signals that the relying party does not recognize a credential ID.
+     *
+     * [origin] is only for browsers or privileged apps acting for another application. Ordinary
+     * apps must leave it `null`; on Android 14+ a non-null value also requires
+     * `android.permission.CREDENTIAL_MANAGER_SET_ORIGIN`.
+     */
+    public suspend fun signalUnknownCredential(
+        rpId: RpId,
+        credentialId: CredentialId,
+        origin: Origin? = null,
+    ): PasskeyResult<Unit> {
+        return signalCredentialState(
+            SignalUnknownCredentialRequest(
+                requestJson = JSONObject()
+                    .put(RP_ID_KEY, rpId.value)
+                    .put(CREDENTIAL_ID_KEY, credentialId.value.encoded())
+                    .toString(),
+                origin = origin?.value,
+            ),
+        )
+    }
+
+    /**
+     * Signals the current user name and display name for a server-side account.
+     *
+     * [origin] is only for browsers or privileged apps acting for another application. Ordinary
+     * apps must leave it `null`; on Android 14+ a non-null value also requires
+     * `android.permission.CREDENTIAL_MANAGER_SET_ORIGIN`.
+     */
+    public suspend fun signalCurrentUserDetails(
+        rpId: RpId,
+        userId: UserHandle,
+        name: String,
+        displayName: String,
+        origin: Origin? = null,
+    ): PasskeyResult<Unit> {
+        return signalCredentialState(
+            SignalCurrentUserDetailsRequest(
+                requestJson = JSONObject()
+                    .put(RP_ID_KEY, rpId.value)
+                    .put(USER_ID_KEY, userId.value.encoded())
+                    .put(NAME_KEY, name)
+                    .put(DISPLAY_NAME_KEY, displayName)
+                    .toString(),
+                origin = origin?.value,
+            ),
+        )
+    }
+
+    private suspend fun signalCredentialState(request: SignalCredentialStateRequest): PasskeyResult<Unit> {
+        return suspendCatchingNonCancellation {
+            credentialManagerFactory(context).signalCredentialState(request)
+        }.fold(
+            onSuccess = { PasskeyResult.Success(Unit) },
+            onFailure = { PasskeyResult.Failure(mapSignalError(it)) },
+        )
+    }
+
+    private fun mapSignalError(error: Throwable): PasskeyClientError = when (error) {
+        is IllegalArgumentException -> PasskeyClientError.InvalidOptions(
+            error.message ?: "Invalid credential signal request",
+        )
+        is SignalCredentialStateException -> PasskeyClientError.Platform(
+            error.message ?: "Credential signal failed",
+        )
+        is SecurityException -> PasskeyClientError.Platform(
+            error.message ?: "Credential signal not permitted",
+        )
+        else -> PasskeyClientError.Platform(error.message ?: "Credential signal failed")
+    }
+
+    private companion object {
+        const val RP_ID_KEY = "rpId"
+        const val USER_ID_KEY = "userId"
+        const val ACCEPTED_CREDENTIAL_IDS_KEY = "allAcceptedCredentialIds"
+        const val CREDENTIAL_ID_KEY = "credentialId"
+        const val NAME_KEY = "name"
+        const val DISPLAY_NAME_KEY = "displayName"
+    }
+}

--- a/docs/site/content/mobile/compose.md
+++ b/docs/site/content/mobile/compose.md
@@ -29,8 +29,13 @@ The repository sample keeps the flow stable across recomposition and leaves coor
 ```kotlin
     val flow = rememberPasskeyFlow(passkeyClient)
     val scope = rememberCoroutineScope()
-    val coordinator = remember(config, debugLogs, sessionStore) {
-        AuthDemoCoordinator(config, debugLogs, sessionStore)
+    val coordinator = remember(config, debugLogs, sessionStore, credentialSignalClient) {
+        AuthDemoCoordinator(
+            config = config,
+            debugLogs = debugLogs,
+            sessionStore = sessionStore,
+            credentialSignalClient = credentialSignalClient,
+        )
     }
     var state by remember { mutableStateOf<DemoCeremonyState>(DemoCeremonyState.Idle) }
     val canRegister by coordinator.canRegister.collectAsState()

--- a/documentation/example-inventory.md
+++ b/documentation/example-inventory.md
@@ -4,7 +4,7 @@
 This inventory is generated from the inline `doc-example` directives. It records every user-facing fenced
 example, its single source of truth, and its strongest automated or illustrative verification level.
 
-Managed blocks: **136**
+Managed blocks: **137**
 
 | ID | File | Purpose | Language | Audience | Owner | Source of truth | Verification | Exception |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -41,10 +41,11 @@ Managed blocks: **136**
 | client-webauthn-client-ktor-kotlinx-readme-kotlin-1 | client/webauthn-client-ktor-kotlinx/README.md:27 | How to use | kotlin | consumer | source | documentation/examples/src/commonMain/kotlin/dev/webauthn/documentation/examples/KtorClientExample.kt#kotlinx-ktor-backend | compile |  |
 | client-webauthn-client-ktor-readme-kotlin-1 | client/webauthn-client-ktor/README.md:28 | How to use | kotlin | consumer | source | documentation/examples/src/commonMain/kotlin/dev/webauthn/documentation/examples/KtorClientExample.kt#neutral-ktor-backend | compile |  |
 | client-webauthn-client-ktor-readme-mermaid-1 | client/webauthn-client-ktor/README.md:84 | How it fits in the system | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
-| client-webauthn-client-platform-readme-kotlin-1 | client/webauthn-client-platform/README.md:27 | Android | kotlin | consumer | source | documentation/examples/src/androidMain/kotlin/dev/webauthn/documentation/examples/AndroidClientExample.kt#android-client | platform-compile |  |
-| client-webauthn-client-platform-readme-kotlin-3 | client/webauthn-client-platform/README.md:43 | Android | kotlin | consumer | source | documentation/examples/src/androidMain/kotlin/dev/webauthn/documentation/examples/AndroidRestoreCredentialExample.kt#android-restore-client | platform-compile |  |
-| client-webauthn-client-platform-readme-kotlin-2 | client/webauthn-client-platform/README.md:82 | iOS | kotlin | consumer | source | documentation/examples/src/iosMain/kotlin/dev/webauthn/documentation/examples/IosClientExample.kt#ios-client | platform-compile |  |
-| client-webauthn-client-platform-readme-mermaid-1 | client/webauthn-client-platform/README.md:95 | How it fits | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
+| client-webauthn-client-platform-readme-kotlin-1 | client/webauthn-client-platform/README.md:29 | Android | kotlin | consumer | source | documentation/examples/src/androidMain/kotlin/dev/webauthn/documentation/examples/AndroidClientExample.kt#android-client | platform-compile |  |
+| client-webauthn-client-platform-readme-kotlin-3 | client/webauthn-client-platform/README.md:45 | Android | kotlin | consumer | source | documentation/examples/src/androidMain/kotlin/dev/webauthn/documentation/examples/AndroidRestoreCredentialExample.kt#android-restore-client | platform-compile |  |
+| client-webauthn-client-platform-readme-kotlin-4 | client/webauthn-client-platform/README.md:85 | Android | kotlin | consumer | source | documentation/examples/src/androidMain/kotlin/dev/webauthn/documentation/examples/AndroidCredentialSignalExample.kt#android-credential-signals | platform-compile |  |
+| client-webauthn-client-platform-readme-kotlin-2 | client/webauthn-client-platform/README.md:120 | iOS | kotlin | consumer | source | documentation/examples/src/iosMain/kotlin/dev/webauthn/documentation/examples/IosClientExample.kt#ios-client | platform-compile |  |
+| client-webauthn-client-platform-readme-mermaid-1 | client/webauthn-client-platform/README.md:133 | How it fits | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
 | client-webauthn-client-prf-crypto-readme-mermaid-1 | client/webauthn-client-prf-crypto/README.md:14 | What it provides | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
 | client-webauthn-client-prf-crypto-readme-kotlin-1 | client/webauthn-client-prf-crypto/README.md:36 | How to use | kotlin | consumer | source | documentation/examples/src/commonMain/kotlin/dev/webauthn/documentation/examples/PrfCryptoExample.kt#prf-crypto | compile |  |
 | core-webauthn-cbor-core-readme-mermaid-1 | core/webauthn-cbor-core/README.md:17 | How it fits in the system | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
@@ -111,21 +112,21 @@ Managed blocks: **136**
 | platform-bom-readme-mermaid-1 | platform/bom/README.md:38 | Fit in the system | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
 | sample-backend-ktor-readme-bash-1 | sample/backend-ktor/README.md:20 | Run | bash | consumer | markdown | Markdown block | syntax |  |
 | sample-backend-ktor-readme-bash-2 | sample/backend-ktor/README.md:45 | ngrok helper | bash | consumer | markdown | Markdown block | syntax |  |
-| sample-compose-passkey-ios-readme-bash-1 | sample/compose-passkey-ios/README.md:20 | Quick run on a device with a free Apple account | bash | consumer | markdown | Markdown block | syntax |  |
-| sample-compose-passkey-ios-readme-bash-2 | sample/compose-passkey-ios/README.md:46 | Complete passkey path with Associated Domains | bash | consumer | markdown | Markdown block | syntax |  |
-| sample-compose-passkey-ios-readme-bash-3 | sample/compose-passkey-ios/README.md:102 | Maintaining this project | bash | contributor | markdown | Markdown block | syntax |  |
+| sample-compose-passkey-ios-readme-bash-1 | sample/compose-passkey-ios/README.md:21 | Quick run on a device with a free Apple account | bash | consumer | markdown | Markdown block | syntax |  |
+| sample-compose-passkey-ios-readme-bash-2 | sample/compose-passkey-ios/README.md:47 | Complete passkey path with Associated Domains | bash | consumer | markdown | Markdown block | syntax |  |
+| sample-compose-passkey-ios-readme-bash-3 | sample/compose-passkey-ios/README.md:116 | Maintaining this project | bash | contributor | markdown | Markdown block | syntax |  |
 | sample-compose-passkey-readiness-checklist-bash-1 | sample/compose-passkey/READINESS_CHECKLIST.md:10 | 1. Build and automated checks | bash | consumer | markdown | Markdown block | syntax |  |
 | sample-compose-passkey-readiness-checklist-bash-2 | sample/compose-passkey/READINESS_CHECKLIST.md:31 | 2. Local sample backend | bash | consumer | markdown | Markdown block | syntax |  |
 | sample-compose-passkey-readiness-checklist-bash-3 | sample/compose-passkey/READINESS_CHECKLIST.md:38 | 2. Local sample backend | bash | consumer | markdown | Markdown block | syntax |  |
 | sample-compose-passkey-readiness-checklist-bash-4 | sample/compose-passkey/READINESS_CHECKLIST.md:66 | 3. Android manual flow (required) | bash | consumer | markdown | Markdown block | syntax |  |
 | sample-compose-passkey-readiness-checklist-bash-5 | sample/compose-passkey/READINESS_CHECKLIST.md:83 | 3. Android manual flow (required) | bash | consumer | markdown | Markdown block | syntax |  |
 | sample-compose-passkey-readiness-checklist-bash-6 | sample/compose-passkey/READINESS_CHECKLIST.md:110 | 5. Debug trace verification | bash | consumer | markdown | Markdown block | syntax |  |
-| sample-compose-passkey-readiness-checklist-bash-7 | sample/compose-passkey/READINESS_CHECKLIST.md:131 | 6. Optional emulator smoke run | bash | consumer | markdown | Markdown block | syntax |  |
-| sample-compose-passkey-readme-bash-1 | sample/compose-passkey/README.md:46 | Run (Android) | bash | consumer | markdown | Markdown block | syntax |  |
-| sample-compose-passkey-readme-bash-2 | sample/compose-passkey/README.md:53 | Run (Android) | bash | consumer | markdown | Markdown block | syntax |  |
-| sample-compose-passkey-readme-bash-3 | sample/compose-passkey/README.md:72 | Run (Android) | bash | consumer | markdown | Markdown block | syntax |  |
-| sample-compose-passkey-readme-bash-4 | sample/compose-passkey/README.md:86 | Run (Android) | bash | consumer | markdown | Markdown block | syntax |  |
-| sample-compose-passkey-readme-kotlin-1 | sample/compose-passkey/README.md:144 | Auth route showcase | kotlin | consumer | sample | sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/screens/auth/AuthRoute.kt#compose-sample-auth-route | sample-build |  |
+| sample-compose-passkey-readiness-checklist-bash-7 | sample/compose-passkey/READINESS_CHECKLIST.md:132 | 6. Optional emulator smoke run | bash | consumer | markdown | Markdown block | syntax |  |
+| sample-compose-passkey-readme-bash-1 | sample/compose-passkey/README.md:47 | Run (Android) | bash | consumer | markdown | Markdown block | syntax |  |
+| sample-compose-passkey-readme-bash-2 | sample/compose-passkey/README.md:54 | Run (Android) | bash | consumer | markdown | Markdown block | syntax |  |
+| sample-compose-passkey-readme-bash-3 | sample/compose-passkey/README.md:73 | Run (Android) | bash | consumer | markdown | Markdown block | syntax |  |
+| sample-compose-passkey-readme-bash-4 | sample/compose-passkey/README.md:87 | Run (Android) | bash | consumer | markdown | Markdown block | syntax |  |
+| sample-compose-passkey-readme-kotlin-1 | sample/compose-passkey/README.md:146 | Auth route showcase | kotlin | consumer | sample | sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/screens/auth/AuthRoute.kt#compose-sample-auth-route | sample-build |  |
 | sample-passkey-cli-readme-bash-1 | sample/passkey-cli/README.md:24 | Prerequisites | bash | consumer | markdown | Markdown block | syntax |  |
 | sample-passkey-cli-readme-bash-2 | sample/passkey-cli/README.md:36 | Commands | bash | consumer | markdown | Markdown block | syntax |  |
 | sample-passkey-cli-readme-bash-3 | sample/passkey-cli/README.md:60 | Local Smoke Path (opt-in) | bash | consumer | markdown | Markdown block | syntax |  |

--- a/documentation/example-inventory.md
+++ b/documentation/example-inventory.md
@@ -4,7 +4,7 @@
 This inventory is generated from the inline `doc-example` directives. It records every user-facing fenced
 example, its single source of truth, and its strongest automated or illustrative verification level.
 
-Managed blocks: **112**
+Managed blocks: **113**
 
 | ID | File | Purpose | Language | Audience | Owner | Source of truth | Verification | Exception |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -41,10 +41,11 @@ Managed blocks: **112**
 | client-webauthn-client-ktor-kotlinx-readme-kotlin-1 | client/webauthn-client-ktor-kotlinx/README.md:27 | How to use | kotlin | consumer | source | documentation/examples/src/commonMain/kotlin/dev/webauthn/documentation/examples/KtorClientExample.kt#kotlinx-ktor-backend | compile |  |
 | client-webauthn-client-ktor-readme-kotlin-1 | client/webauthn-client-ktor/README.md:28 | How to use | kotlin | consumer | source | documentation/examples/src/commonMain/kotlin/dev/webauthn/documentation/examples/KtorClientExample.kt#neutral-ktor-backend | compile |  |
 | client-webauthn-client-ktor-readme-mermaid-1 | client/webauthn-client-ktor/README.md:84 | How it fits in the system | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
-| client-webauthn-client-platform-readme-kotlin-1 | client/webauthn-client-platform/README.md:27 | Android | kotlin | consumer | source | documentation/examples/src/androidMain/kotlin/dev/webauthn/documentation/examples/AndroidClientExample.kt#android-client | platform-compile |  |
-| client-webauthn-client-platform-readme-kotlin-3 | client/webauthn-client-platform/README.md:43 | Android | kotlin | consumer | source | documentation/examples/src/androidMain/kotlin/dev/webauthn/documentation/examples/AndroidRestoreCredentialExample.kt#android-restore-client | platform-compile |  |
-| client-webauthn-client-platform-readme-kotlin-2 | client/webauthn-client-platform/README.md:82 | iOS | kotlin | consumer | source | documentation/examples/src/iosMain/kotlin/dev/webauthn/documentation/examples/IosClientExample.kt#ios-client | platform-compile |  |
-| client-webauthn-client-platform-readme-mermaid-1 | client/webauthn-client-platform/README.md:95 | How it fits | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
+| client-webauthn-client-platform-readme-kotlin-1 | client/webauthn-client-platform/README.md:29 | Android | kotlin | consumer | source | documentation/examples/src/androidMain/kotlin/dev/webauthn/documentation/examples/AndroidClientExample.kt#android-client | platform-compile |  |
+| client-webauthn-client-platform-readme-kotlin-3 | client/webauthn-client-platform/README.md:45 | Android | kotlin | consumer | source | documentation/examples/src/androidMain/kotlin/dev/webauthn/documentation/examples/AndroidRestoreCredentialExample.kt#android-restore-client | platform-compile |  |
+| client-webauthn-client-platform-readme-kotlin-4 | client/webauthn-client-platform/README.md:85 | Android | kotlin | consumer | source | documentation/examples/src/androidMain/kotlin/dev/webauthn/documentation/examples/AndroidCredentialSignalExample.kt#android-credential-signals | platform-compile |  |
+| client-webauthn-client-platform-readme-kotlin-2 | client/webauthn-client-platform/README.md:120 | iOS | kotlin | consumer | source | documentation/examples/src/iosMain/kotlin/dev/webauthn/documentation/examples/IosClientExample.kt#ios-client | platform-compile |  |
+| client-webauthn-client-platform-readme-mermaid-1 | client/webauthn-client-platform/README.md:133 | How it fits | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
 | client-webauthn-client-prf-crypto-readme-mermaid-1 | client/webauthn-client-prf-crypto/README.md:14 | What it provides | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
 | client-webauthn-client-prf-crypto-readme-kotlin-1 | client/webauthn-client-prf-crypto/README.md:36 | How to use | kotlin | consumer | source | documentation/examples/src/commonMain/kotlin/dev/webauthn/documentation/examples/PrfCryptoExample.kt#prf-crypto | compile |  |
 | core-webauthn-cbor-core-readme-mermaid-1 | core/webauthn-cbor-core/README.md:17 | How it fits in the system | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
@@ -87,21 +88,21 @@ Managed blocks: **112**
 | platform-bom-readme-mermaid-1 | platform/bom/README.md:38 | Fit in the system | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
 | sample-backend-ktor-readme-bash-1 | sample/backend-ktor/README.md:20 | Run | bash | consumer | markdown | Markdown block | syntax |  |
 | sample-backend-ktor-readme-bash-2 | sample/backend-ktor/README.md:45 | ngrok helper | bash | consumer | markdown | Markdown block | syntax |  |
-| sample-compose-passkey-ios-readme-bash-1 | sample/compose-passkey-ios/README.md:20 | Quick run on device (free Apple account) | bash | consumer | markdown | Markdown block | syntax |  |
-| sample-compose-passkey-ios-readme-bash-2 | sample/compose-passkey-ios/README.md:46 | Full passkey E2E path (Associated Domains capable setup) | bash | consumer | markdown | Markdown block | syntax |  |
-| sample-compose-passkey-ios-readme-bash-3 | sample/compose-passkey-ios/README.md:102 | Maintaining this project | bash | contributor | markdown | Markdown block | syntax |  |
+| sample-compose-passkey-ios-readme-bash-1 | sample/compose-passkey-ios/README.md:21 | Quick run on device (free Apple account) | bash | consumer | markdown | Markdown block | syntax |  |
+| sample-compose-passkey-ios-readme-bash-2 | sample/compose-passkey-ios/README.md:47 | Full passkey E2E path (Associated Domains capable setup) | bash | consumer | markdown | Markdown block | syntax |  |
+| sample-compose-passkey-ios-readme-bash-3 | sample/compose-passkey-ios/README.md:116 | Maintaining this project | bash | contributor | markdown | Markdown block | syntax |  |
 | sample-compose-passkey-readiness-checklist-bash-1 | sample/compose-passkey/READINESS_CHECKLIST.md:10 | 1. Build and automated checks | bash | consumer | markdown | Markdown block | syntax |  |
 | sample-compose-passkey-readiness-checklist-bash-2 | sample/compose-passkey/READINESS_CHECKLIST.md:31 | 2. Local sample backend | bash | consumer | markdown | Markdown block | syntax |  |
 | sample-compose-passkey-readiness-checklist-bash-3 | sample/compose-passkey/READINESS_CHECKLIST.md:38 | 2. Local sample backend | bash | consumer | markdown | Markdown block | syntax |  |
 | sample-compose-passkey-readiness-checklist-bash-4 | sample/compose-passkey/READINESS_CHECKLIST.md:66 | 3. Android manual flow (required) | bash | consumer | markdown | Markdown block | syntax |  |
 | sample-compose-passkey-readiness-checklist-bash-5 | sample/compose-passkey/READINESS_CHECKLIST.md:83 | 3. Android manual flow (required) | bash | consumer | markdown | Markdown block | syntax |  |
 | sample-compose-passkey-readiness-checklist-bash-6 | sample/compose-passkey/READINESS_CHECKLIST.md:110 | 5. Debug trace verification | bash | consumer | markdown | Markdown block | syntax |  |
-| sample-compose-passkey-readiness-checklist-bash-7 | sample/compose-passkey/READINESS_CHECKLIST.md:131 | 6. Optional emulator smoke run | bash | consumer | markdown | Markdown block | syntax |  |
-| sample-compose-passkey-readme-bash-1 | sample/compose-passkey/README.md:46 | Run (Android) | bash | consumer | markdown | Markdown block | syntax |  |
-| sample-compose-passkey-readme-bash-2 | sample/compose-passkey/README.md:53 | Run (Android) | bash | consumer | markdown | Markdown block | syntax |  |
-| sample-compose-passkey-readme-bash-3 | sample/compose-passkey/README.md:72 | Run (Android) | bash | consumer | markdown | Markdown block | syntax |  |
-| sample-compose-passkey-readme-bash-4 | sample/compose-passkey/README.md:86 | Run (Android) | bash | consumer | markdown | Markdown block | syntax |  |
-| sample-compose-passkey-readme-kotlin-1 | sample/compose-passkey/README.md:144 | Auth route showcase | kotlin | consumer | sample | sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/screens/auth/AuthRoute.kt#compose-sample-auth-route | sample-build |  |
+| sample-compose-passkey-readiness-checklist-bash-7 | sample/compose-passkey/READINESS_CHECKLIST.md:132 | 6. Optional emulator smoke run | bash | consumer | markdown | Markdown block | syntax |  |
+| sample-compose-passkey-readme-bash-1 | sample/compose-passkey/README.md:47 | Run (Android) | bash | consumer | markdown | Markdown block | syntax |  |
+| sample-compose-passkey-readme-bash-2 | sample/compose-passkey/README.md:54 | Run (Android) | bash | consumer | markdown | Markdown block | syntax |  |
+| sample-compose-passkey-readme-bash-3 | sample/compose-passkey/README.md:73 | Run (Android) | bash | consumer | markdown | Markdown block | syntax |  |
+| sample-compose-passkey-readme-bash-4 | sample/compose-passkey/README.md:87 | Run (Android) | bash | consumer | markdown | Markdown block | syntax |  |
+| sample-compose-passkey-readme-kotlin-1 | sample/compose-passkey/README.md:146 | Auth route showcase | kotlin | consumer | sample | sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/screens/auth/AuthRoute.kt#compose-sample-auth-route | sample-build |  |
 | sample-passkey-cli-readme-bash-1 | sample/passkey-cli/README.md:24 | Prerequisites | bash | consumer | markdown | Markdown block | syntax |  |
 | sample-passkey-cli-readme-bash-2 | sample/passkey-cli/README.md:36 | Commands | bash | consumer | markdown | Markdown block | syntax |  |
 | sample-passkey-cli-readme-bash-3 | sample/passkey-cli/README.md:60 | Local Smoke Path (opt-in) | bash | consumer | markdown | Markdown block | syntax |  |

--- a/documentation/examples/src/androidMain/kotlin/dev/webauthn/documentation/examples/AndroidCredentialSignalExample.kt
+++ b/documentation/examples/src/androidMain/kotlin/dev/webauthn/documentation/examples/AndroidCredentialSignalExample.kt
@@ -1,0 +1,30 @@
+package dev.webauthn.documentation.examples
+
+// docs-region android-credential-signals
+import android.app.Activity
+import dev.webauthn.client.PasskeyResult
+import dev.webauthn.client.android.AndroidCredentialSignalClient
+import dev.webauthn.model.CredentialId
+import dev.webauthn.model.RpId
+import dev.webauthn.model.UserHandle
+
+suspend fun reconcileCredentialManager(
+    activity: Activity,
+    rpId: RpId,
+    userHandle: UserHandle,
+    acceptedCredentialIds: List<CredentialId>,
+    unknownCredentialId: CredentialId,
+): Triple<PasskeyResult<Unit>, PasskeyResult<Unit>, PasskeyResult<Unit>> {
+    val signals = AndroidCredentialSignalClient(activity.applicationContext)
+    return Triple(
+        signals.signalAllAcceptedCredentialIds(rpId, userHandle, acceptedCredentialIds),
+        signals.signalUnknownCredential(rpId, unknownCredentialId),
+        signals.signalCurrentUserDetails(
+            rpId = rpId,
+            userId = userHandle,
+            name = "demo@example.com",
+            displayName = "Demo User",
+        ),
+    )
+}
+// docs-endregion android-credential-signals

--- a/sample/compose-passkey-ios/ComposePasskeyIos.xcodeproj/project.pbxproj
+++ b/sample/compose-passkey-ios/ComposePasskeyIos.xcodeproj/project.pbxproj
@@ -10,10 +10,12 @@
 		285CB960E67F5D7493B47868 /* ComposePasskeyIosApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A72121BAA5A0037AE74FEA /* ComposePasskeyIosApp.swift */; };
 		729ECCE037B334E608061C3B /* ComposePasskeyShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 020E8BEC08EDAB193162C8F0 /* ComposePasskeyShared.framework */; };
 		EEA0A397E433A3BC1D8E6F51 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D05536FE2830CD3C83D94EDF /* Assets.xcassets */; };
+		F2EC0E427B8EA5AE159C950D /* IosCredentialSignalBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0213E5FA8F185AD766C9B2D /* IosCredentialSignalBridge.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		020E8BEC08EDAB193162C8F0 /* ComposePasskeyShared.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ComposePasskeyShared.framework; path = "$SRCROOT/../compose-passkey/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)/ComposePasskeyShared.framework"; sourceTree = "<group>"; };
+		A0213E5FA8F185AD766C9B2D /* IosCredentialSignalBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IosCredentialSignalBridge.swift; sourceTree = "<group>"; };
 		D05536FE2830CD3C83D94EDF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		EC8470A115D06D044F4D7D79 /* ComposePasskeyIos.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ComposePasskeyIos.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F3A72121BAA5A0037AE74FEA /* ComposePasskeyIosApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposePasskeyIosApp.swift; sourceTree = "<group>"; };
@@ -45,6 +47,7 @@
 			children = (
 				D05536FE2830CD3C83D94EDF /* Assets.xcassets */,
 				F3A72121BAA5A0037AE74FEA /* ComposePasskeyIosApp.swift */,
+				A0213E5FA8F185AD766C9B2D /* IosCredentialSignalBridge.swift */,
 			);
 			path = ComposePasskeyIos;
 			sourceTree = "<group>";
@@ -158,6 +161,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				285CB960E67F5D7493B47868 /* ComposePasskeyIosApp.swift in Sources */,
+				F2EC0E427B8EA5AE159C950D /* IosCredentialSignalBridge.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/sample/compose-passkey-ios/ComposePasskeyIos/ComposePasskeyIosApp.swift
+++ b/sample/compose-passkey-ios/ComposePasskeyIos/ComposePasskeyIosApp.swift
@@ -30,7 +30,9 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
 
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = MainViewControllerKt.MainViewController()
+        window.rootViewController = MainViewControllerKt.MainViewController(
+            credentialSignalBridge: AuthenticationServicesCredentialSignalBridge(),
+        )
         self.window = window
         window.makeKeyAndVisible()
     }

--- a/sample/compose-passkey-ios/ComposePasskeyIos/IosCredentialSignalBridge.swift
+++ b/sample/compose-passkey-ios/ComposePasskeyIos/IosCredentialSignalBridge.swift
@@ -1,0 +1,69 @@
+import AuthenticationServices
+import ComposePasskeyShared
+import Foundation
+
+final class AuthenticationServicesCredentialSignalBridge: ComposePasskeyShared.IosCredentialSignalBridge {
+    var isAvailable: Bool {
+        if #available(iOS 26.2, *) {
+            return true
+        }
+        return false
+    }
+
+    func reportCurrentUserDetails(
+        relyingPartyIdentifier: String,
+        userHandleBase64Url: String,
+        name: String,
+        displayName: String,
+        completion: @escaping (String?) -> Void,
+    ) {
+        guard let userHandle = Data(base64URLEncoded: userHandleBase64Url) else {
+            completion("Invalid base64url user handle for iOS credential signal.")
+            return
+        }
+
+        if #available(iOS 26.2, *) {
+            let completionBox = CredentialSignalCompletionBox(completion)
+            Task {
+                do {
+                    try await ASCredentialDataManager().reportPublicKeyCredentialUpdate(
+                        relyingPartyIdentifier: relyingPartyIdentifier,
+                        userHandle: userHandle,
+                        newName: name,
+                    )
+                    await completionBox.complete(nil)
+                } catch {
+                    await completionBox.complete(error.localizedDescription)
+                }
+            }
+        } else {
+            completion("iOS credential signals require iOS 26.2+ ASCredentialDataManager.")
+        }
+    }
+}
+
+private final class CredentialSignalCompletionBox: @unchecked Sendable {
+    private let completion: (String?) -> Void
+
+    init(_ completion: @escaping (String?) -> Void) {
+        self.completion = completion
+    }
+
+    @MainActor
+    func complete(_ errorMessage: String?) {
+        completion(errorMessage)
+    }
+}
+
+private extension Data {
+    init?(base64URLEncoded value: String) {
+        var base64 = value
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let padding = base64.count % 4
+        if padding > 0 {
+            base64.append(String(repeating: "=", count: 4 - padding))
+        }
+        self.init(base64Encoded: base64)
+    }
+}

--- a/sample/compose-passkey-ios/README.md
+++ b/sample/compose-passkey-ios/README.md
@@ -9,6 +9,7 @@ Use this sample when you want to run the passkey demo on a connected iPhone from
 - A committed Xcode app project (`ComposePasskeyIos.xcodeproj`).
 - SwiftUI app shell that mounts Kotlin `MainViewController()` from `sample:compose-passkey`.
 - Build phase script that runs `:sample:compose-passkey:embedAndSignAppleFrameworkForXcode`.
+- Swift bridge for iOS credential signals using `ASCredentialDataManager` when running on iOS 26.2+.
 
 ## Quick run on device (free Apple account)
 
@@ -65,6 +66,19 @@ Expected result:
 - `Sign In` completes.
 - Signed-in extension demo screen is shown after successful sign-in.
 - `PasskeyDemo` logs appear in Xcode console and in the hidden in-app debug sheet (title double-tap).
+- On iOS 26.2+, the app reports the signed-in user name to AuthenticationServices through the Swift credential-signal bridge.
+
+## iOS credential signal bridge
+
+The shared Kotlin module exports `IosCredentialSignalBridge` because Kotlin/Native does not currently
+expose Swift-only `ASCredentialDataManager` bindings under `platform.AuthenticationServices`.
+`AuthenticationServicesCredentialSignalBridge` implements that protocol in Swift and is passed into
+`MainViewController(...)` by the host app.
+
+Availability expectations:
+
+- iOS 26.2+: `reportPublicKeyCredentialUpdate(...)` is called after successful sign-in.
+- Older iOS versions: the bridge reports unavailable and the sample logs that credential signals require iOS 26.2+.
 
 ## Environment variables used by the shared sample
 

--- a/sample/compose-passkey-ios/README.md
+++ b/sample/compose-passkey-ios/README.md
@@ -9,6 +9,7 @@ Use this sample when you want to run the passkey demo on a connected iPhone from
 - A committed Xcode app project (`ComposePasskeyIos.xcodeproj`).
 - SwiftUI app shell that mounts Kotlin `MainViewController()` from `sample:compose-passkey`.
 - Build phase script that runs `:sample:compose-passkey:embedAndSignAppleFrameworkForXcode`.
+- Swift bridge for iOS credential signals using `ASCredentialDataManager` when running on iOS 26.2+.
 
 ## Quick run on a device with a free Apple account
 
@@ -65,6 +66,19 @@ Expected result:
 - `Sign In` completes.
 - Signed-in extension demo screen is shown after successful sign-in.
 - `PasskeyDemo` logs appear in Xcode console and in the hidden in-app debug sheet (title double-tap).
+- On iOS 26.2+, the app reports the signed-in user name to AuthenticationServices through the Swift credential-signal bridge.
+
+## iOS credential signal bridge
+
+The shared Kotlin module exports `IosCredentialSignalBridge` because Kotlin/Native does not currently
+expose Swift-only `ASCredentialDataManager` bindings under `platform.AuthenticationServices`.
+`AuthenticationServicesCredentialSignalBridge` implements that protocol in Swift and is passed into
+`MainViewController(...)` by the host app.
+
+Availability expectations:
+
+- iOS 26.2+: `reportPublicKeyCredentialUpdate(...)` is called after successful sign-in.
+- Older iOS versions: the bridge reports unavailable and the sample logs that credential signals require iOS 26.2+.
 
 ## Environment variables used by the shared sample
 

--- a/sample/compose-passkey/READINESS_CHECKLIST.md
+++ b/sample/compose-passkey/READINESS_CHECKLIST.md
@@ -116,6 +116,7 @@ Pass condition:
 - app/action/flow/http events are present and readable.
 - HTTP entries contain request/response metadata without bodies under the default
   configuration.
+- on Android, successful sign-in logs a `signals` entry when Credential Manager accepts or rejects the current-user-details signal.
 - in-app debug sheet opens from the explicit `Logs` header action on both screens.
 
 For an isolated debugging session, build with

--- a/sample/compose-passkey/README.md
+++ b/sample/compose-passkey/README.md
@@ -14,6 +14,7 @@ A Compose Multiplatform app for a minimal end-to-end passkey flow against `sampl
 8. Explicit `Logs` action in the shared header opening an in-app debug log sheet (wall-clock timestamps, level, source, message).
 9. Structured ceremony + network logs emitted with tag `PasskeyDemo`.
 10. Android Restore Credentials demo card: create a restore key with the normal registration options, test retrieval through the normal sign-in finish path, and clear the restore key during local sign-out.
+11. Credential-manager signal demo: after successful sign-in, the sample sends a current-user-details signal through Android Credential Manager or the iOS host bridge and logs the outcome.
 
 These values are baked into the shared app during build:
 
@@ -121,6 +122,7 @@ The sample emits structured logs with tag `PasskeyDemo` and uses the same entrie
 - `capabilities`: probe start/success/failure
 - `action`: register/auto-create/sign-in taps
 - `prf`: PRF sign-in/session/encrypt/decrypt outcomes
+- `signals`: platform credential-manager signal outcomes
 - `flow`: state transitions (`STARTING`, `PLATFORM_PROMPT`, `FINISHING`, terminal outcomes)
 - `http`: Ktor request/response metadata (method, URL, and status)
 
@@ -144,8 +146,13 @@ The auth screen is intentionally the cleanest API example in the repo:
 ```kotlin
     val flow = rememberPasskeyFlow(passkeyClient)
     val scope = rememberCoroutineScope()
-    val coordinator = remember(config, debugLogs, sessionStore) {
-        AuthDemoCoordinator(config, debugLogs, sessionStore)
+    val coordinator = remember(config, debugLogs, sessionStore, credentialSignalClient) {
+        AuthDemoCoordinator(
+            config = config,
+            debugLogs = debugLogs,
+            sessionStore = sessionStore,
+            credentialSignalClient = credentialSignalClient,
+        )
     }
     var state by remember { mutableStateOf<DemoCeremonyState>(DemoCeremonyState.Idle) }
     val canRegister by coordinator.canRegister.collectAsState()
@@ -155,6 +162,7 @@ The auth screen is intentionally the cleanest API example in the repo:
 Sample-only side effects stay outside the library API surface:
 
 - `AuthDemoCoordinator` logs taps/state transitions.
+- `AuthDemoCoordinator` sends the platform current-user-details signal after successful sign-in when the platform client is available.
 - `AppSessionStore` handles local signed-in navigation state.
 
 ## Android Restore Credentials showcase
@@ -179,6 +187,27 @@ This card is a development harness for the create/get/clear API shape. A true de
 validation still needs Android backup/restore or first-launch testing on a restored device. iOS shows
 the card as unavailable because Apple passkeys sync through iCloud Keychain, but AuthenticationServices
 does not expose an app-managed Restore Credentials equivalent.
+
+## Credential signal showcase
+
+After successful sign-in, the sample can send a current-user-details signal to the platform
+credential manager and log whether the platform accepted well-formed parameters. Android uses the
+published `AndroidCredentialSignalClient`; the iOS host injects a sample-owned Swift bridge. Neither
+path replaces server-side credential-state enforcement.
+
+The sample only exercises `SignalCurrentUserDetailsRequest` because it already has the RP ID, stable
+user handle, and display name during sign-in. `SignalAllAcceptedCredentialIdsRequest` and
+`SignalUnknownCredentialRequest` require a real server-side credential inventory or an unknown
+credential failure path. Those operations remain available through the Android platform API but are
+not exercised by this sample until its backend exposes authoritative credential inventory state.
+
+On iOS, Apple exposes the analogous `ASCredentialDataManager` sync reports from Swift, but the
+current Kotlin/Native SDK bindings do not expose that Swift-only type under
+`platform.AuthenticationServices`. The committed iOS host app therefore injects a tiny Swift
+`IosCredentialSignalBridge` implementation into `MainViewController(...)`; Kotlin owns the sample
+flow, while Swift owns the iOS 26.2+ AuthenticationServices call.
+Apple's update API accepts the RP ID, user handle, and new account name; it has no separate display
+name parameter, so the sample bridge deliberately ignores the common display-name value on iOS.
 
 ## Compose previews
 

--- a/sample/compose-passkey/README.md
+++ b/sample/compose-passkey/README.md
@@ -14,6 +14,7 @@ Compose Multiplatform sample app for a minimal passkey E2E flow against `sample/
 8. Explicit `Logs` action in the shared header opening an in-app debug log sheet (wall-clock timestamps, level, source, message).
 9. Structured ceremony + network logs emitted with tag `PasskeyDemo`.
 10. Android Restore Credentials demo card: create a restore key with the normal registration options, test retrieval through the normal sign-in finish path, and clear the restore key during local sign-out.
+11. Credential-manager signal demo: after successful sign-in, the sample sends a current-user-details signal through Android Credential Manager or the iOS host bridge and logs the outcome.
 
 These values are baked into the shared app during build:
 
@@ -121,6 +122,7 @@ The sample emits structured logs with tag `PasskeyDemo` and uses the same entrie
 - `capabilities`: probe start/success/failure
 - `action`: register/auto-create/sign-in taps
 - `prf`: PRF sign-in/session/encrypt/decrypt outcomes
+- `signals`: platform credential-manager signal outcomes
 - `flow`: state transitions (`STARTING`, `PLATFORM_PROMPT`, `FINISHING`, terminal outcomes)
 - `http`: Ktor request/response metadata (method, URL, and status)
 
@@ -144,8 +146,13 @@ The auth screen is intentionally the cleanest API example in the repo:
 ```kotlin
     val flow = rememberPasskeyFlow(passkeyClient)
     val scope = rememberCoroutineScope()
-    val coordinator = remember(config, debugLogs, sessionStore) {
-        AuthDemoCoordinator(config, debugLogs, sessionStore)
+    val coordinator = remember(config, debugLogs, sessionStore, credentialSignalClient) {
+        AuthDemoCoordinator(
+            config = config,
+            debugLogs = debugLogs,
+            sessionStore = sessionStore,
+            credentialSignalClient = credentialSignalClient,
+        )
     }
     var state by remember { mutableStateOf<DemoCeremonyState>(DemoCeremonyState.Idle) }
     val canRegister by coordinator.canRegister.collectAsState()
@@ -155,6 +162,7 @@ The auth screen is intentionally the cleanest API example in the repo:
 Sample-only side effects stay outside the library API surface:
 
 - `AuthDemoCoordinator` logs taps/state transitions.
+- `AuthDemoCoordinator` sends the platform current-user-details signal after successful sign-in when the platform client is available.
 - `AppSessionStore` handles local signed-in navigation state.
 
 ## Android Restore Credentials showcase
@@ -179,6 +187,27 @@ This card is a development harness for the create/get/clear API shape. A true de
 validation still needs Android backup/restore or first-launch testing on a restored device. iOS shows
 the card as unavailable because Apple passkeys sync through iCloud Keychain, but AuthenticationServices
 does not expose an app-managed Restore Credentials equivalent.
+
+## Credential signal showcase
+
+After successful sign-in, the sample can send a current-user-details signal to the platform
+credential manager and log whether the platform accepted well-formed parameters. Android uses the
+published `AndroidCredentialSignalClient`; the iOS host injects a sample-owned Swift bridge. Neither
+path replaces server-side credential-state enforcement.
+
+The sample only exercises `SignalCurrentUserDetailsRequest` because it already has the RP ID, stable
+user handle, and display name during sign-in. `SignalAllAcceptedCredentialIdsRequest` and
+`SignalUnknownCredentialRequest` require a real server-side credential inventory or an unknown
+credential failure path. Those operations remain available through the Android platform API but are
+not exercised by this sample until its backend exposes authoritative credential inventory state.
+
+On iOS, Apple exposes the analogous `ASCredentialDataManager` sync reports from Swift, but the
+current Kotlin/Native SDK bindings do not expose that Swift-only type under
+`platform.AuthenticationServices`. The committed iOS host app therefore injects a tiny Swift
+`IosCredentialSignalBridge` implementation into `MainViewController(...)`; Kotlin owns the sample
+flow, while Swift owns the iOS 26.2+ AuthenticationServices call.
+Apple's update API accepts the RP ID, user handle, and new account name; it has no separate display
+name parameter, so the sample bridge deliberately ignores the common display-name value on iOS.
 
 ## Compose previews
 

--- a/sample/compose-passkey/src/androidMain/kotlin/dev/webauthn/samples/composepasskey/domain/signals/RememberCredentialSignalDemoClient.android.kt
+++ b/sample/compose-passkey/src/androidMain/kotlin/dev/webauthn/samples/composepasskey/domain/signals/RememberCredentialSignalDemoClient.android.kt
@@ -1,0 +1,37 @@
+package dev.webauthn.samples.composepasskey.domain.signals
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import dev.webauthn.client.PasskeyResult
+import dev.webauthn.client.android.AndroidCredentialSignalClient
+import dev.webauthn.model.RpId
+import dev.webauthn.model.UserHandle
+
+@Composable
+internal actual fun rememberCredentialSignalDemoClient(): CredentialSignalDemoClient {
+    val context = LocalContext.current
+    return remember(context) {
+        AndroidCredentialSignalDemoClient(AndroidCredentialSignalClient(context))
+    }
+}
+
+private class AndroidCredentialSignalDemoClient(
+    private val delegate: AndroidCredentialSignalClient,
+) : CredentialSignalDemoClient {
+    override val isAvailable: Boolean = true
+
+    override suspend fun signalCurrentUserDetails(
+        rpId: RpId,
+        userId: UserHandle,
+        name: String,
+        displayName: String,
+    ): PasskeyResult<Unit> {
+        return delegate.signalCurrentUserDetails(
+            rpId = rpId,
+            userId = userId,
+            name = name,
+            displayName = displayName,
+        )
+    }
+}

--- a/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/app/App.kt
+++ b/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/app/App.kt
@@ -12,6 +12,8 @@ import dev.webauthn.samples.composepasskey.data.network.normalizedEndpoint
 import dev.webauthn.samples.composepasskey.data.network.rememberPlatformHttpClient
 import dev.webauthn.samples.composepasskey.domain.passkey.PasskeyDemoConfig
 import dev.webauthn.samples.composepasskey.domain.restore.rememberRestoreCredentialDemoClient
+import dev.webauthn.samples.composepasskey.domain.signals.CredentialSignalDemoClient
+import dev.webauthn.samples.composepasskey.domain.signals.rememberCredentialSignalDemoClient
 import kotlinx.coroutines.launch
 import org.koin.compose.KoinApplication
 import org.koin.core.logger.Level
@@ -19,6 +21,17 @@ import org.koin.dsl.koinConfiguration
 
 @Composable
 fun App(platformOrigin: String? = null) {
+    App(
+        platformOrigin = platformOrigin,
+        credentialSignalClient = rememberCredentialSignalDemoClient(),
+    )
+}
+
+@Composable
+internal fun App(
+    platformOrigin: String? = null,
+    credentialSignalClient: CredentialSignalDemoClient,
+) {
     val scope = rememberCoroutineScope()
     val debugLogs = remember { DebugLogStore() }
     val httpLogSink: (String) -> Unit = remember(scope, debugLogs) {
@@ -38,12 +51,20 @@ fun App(platformOrigin: String? = null) {
         )
     }
 
-    val modules = remember(config, debugLogs, passkeyClient, restoreCredentialClient, backend) {
+    val modules = remember(
+        config,
+        debugLogs,
+        passkeyClient,
+        restoreCredentialClient,
+        credentialSignalClient,
+        backend,
+    ) {
         sampleAppModules(
             config = config,
             debugLogs = debugLogs,
             passkeyClient = passkeyClient,
             restoreCredentialClient = restoreCredentialClient,
+            credentialSignalClient = credentialSignalClient,
             backend = backend,
         )
     }

--- a/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/app/auth/AuthDemoCoordinator.kt
+++ b/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/app/auth/AuthDemoCoordinator.kt
@@ -1,12 +1,18 @@
 package dev.webauthn.samples.composepasskey.app.auth
 
+import dev.webauthn.client.PasskeyResult
+import dev.webauthn.model.RpId
+import dev.webauthn.model.UserHandle
+import dev.webauthn.model.ValidationResult
 import dev.webauthn.samples.composepasskey.data.logging.DebugLogStore
 import dev.webauthn.samples.composepasskey.data.session.AppSessionStore
 import dev.webauthn.samples.composepasskey.domain.model.DebugLogLevel
-import dev.webauthn.samples.composepasskey.domain.passkey.PasskeyDemoConfig
 import dev.webauthn.samples.composepasskey.domain.passkey.DemoCeremonyState
 import dev.webauthn.samples.composepasskey.domain.passkey.DemoPasskeyAction
+import dev.webauthn.samples.composepasskey.domain.passkey.PasskeyDemoConfig
 import dev.webauthn.samples.composepasskey.domain.passkey.demoTransitionEvent
+import dev.webauthn.samples.composepasskey.domain.passkey.toRegistrationStartPayload
+import dev.webauthn.samples.composepasskey.domain.signals.CredentialSignalDemoClient
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -14,6 +20,7 @@ internal class AuthDemoCoordinator(
     private val config: PasskeyDemoConfig,
     private val debugLogs: DebugLogStore,
     private val sessionStore: AppSessionStore,
+    private val credentialSignalClient: CredentialSignalDemoClient,
 ) {
     val canRegister: StateFlow<Boolean> field = MutableStateFlow<Boolean>(true)
 
@@ -30,28 +37,25 @@ internal class AuthDemoCoordinator(
     fun onRegisterClicked() {
         debugLogs.i(
             source = "action",
-            message = "Register tapped endpoint=${config.endpointBase} " +
-                "rpId=${config.rpId}",
+            message = "Register tapped endpoint=${config.endpointBase} rpId=${config.rpId}",
         )
     }
 
     fun onAutoCreateClicked() {
         debugLogs.i(
             source = "action",
-            message = "Auto Create tapped endpoint=${config.endpointBase} " +
-                "rpId=${config.rpId}",
+            message = "Auto Create tapped endpoint=${config.endpointBase} rpId=${config.rpId}",
         )
     }
 
     fun onSignInClicked() {
         debugLogs.i(
             source = "action",
-            message = "Sign In tapped endpoint=${config.endpointBase} " +
-                "rpId=${config.rpId}",
+            message = "Sign In tapped endpoint=${config.endpointBase} rpId=${config.rpId}",
         )
     }
 
-    fun onCeremonyStateChanged(current: DemoCeremonyState) {
+    suspend fun onCeremonyStateChanged(current: DemoCeremonyState) {
         demoTransitionEvent(previous = previousState, current = current)?.let { event ->
             when (event.level) {
                 DebugLogLevel.DEBUG -> debugLogs.d(source = "flow", message = event.message)
@@ -68,9 +72,46 @@ internal class AuthDemoCoordinator(
 
             current is DemoCeremonyState.Success && current.action == DemoPasskeyAction.SIGN_IN -> {
                 sessionStore.signIn(config.userName)
+                signalCurrentUserDetails()
             }
         }
 
         previousState = current
+    }
+
+    private suspend fun signalCurrentUserDetails() {
+        if (!credentialSignalClient.isAvailable) return
+
+        val rpId = when (val result = RpId.parse(config.rpId)) {
+            is ValidationResult.Valid -> result.value
+            is ValidationResult.Invalid -> {
+                debugLogs.w(source = "signals", message = "Skipped current user details signal: invalid RP ID")
+                return
+            }
+        }
+        val userHandle = when (val result = UserHandle.parse(config.toRegistrationStartPayload().userHandle)) {
+            is ValidationResult.Valid -> result.value
+            is ValidationResult.Invalid -> {
+                debugLogs.w(source = "signals", message = "Skipped current user details signal: invalid user handle")
+                return
+            }
+        }
+
+        when (
+            val result = credentialSignalClient.signalCurrentUserDetails(
+                rpId = rpId,
+                userId = userHandle,
+                name = config.userName,
+                displayName = config.userName,
+            )
+        ) {
+            is PasskeyResult.Success -> {
+                debugLogs.i(source = "signals", message = "Current user details signal accepted")
+            }
+
+            is PasskeyResult.Failure -> {
+                debugLogs.w(source = "signals", message = result.error.message)
+            }
+        }
     }
 }

--- a/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/app/di/SampleAppModules.kt
+++ b/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/app/di/SampleAppModules.kt
@@ -9,6 +9,7 @@ import dev.webauthn.samples.composepasskey.domain.passkey.PasskeyDemoConfig
 import dev.webauthn.samples.composepasskey.domain.prf.InMemoryPrfSaltStore
 import dev.webauthn.samples.composepasskey.domain.prf.PrfSaltStore
 import dev.webauthn.samples.composepasskey.domain.restore.RestoreCredentialDemoClient
+import dev.webauthn.samples.composepasskey.domain.signals.CredentialSignalDemoClient
 import dev.webauthn.samples.composepasskey.ui.screens.auth.AuthRoute
 import dev.webauthn.samples.composepasskey.ui.screens.main.MainRoute
 import dev.webauthn.samples.composepasskey.ui.screens.main.MainViewModel
@@ -24,6 +25,7 @@ internal fun sampleAppModules(
     debugLogs: DebugLogStore,
     passkeyClient: PasskeyClient,
     restoreCredentialClient: RestoreCredentialDemoClient,
+    credentialSignalClient: CredentialSignalDemoClient,
     backend: DemoPasskeyBackend,
 ): List<Module> {
     return listOf(
@@ -32,6 +34,7 @@ internal fun sampleAppModules(
             single<DebugLogStore> { debugLogs }
             single<PasskeyClient> { passkeyClient }
             single<RestoreCredentialDemoClient> { restoreCredentialClient }
+            single<CredentialSignalDemoClient> { credentialSignalClient }
             single<DemoPasskeyBackend> { backend }
             single<AppSessionStore> { AppSessionStore() }
             single<PrfSaltStore> { InMemoryPrfSaltStore() }

--- a/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/domain/signals/CredentialSignalDemoClient.kt
+++ b/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/domain/signals/CredentialSignalDemoClient.kt
@@ -1,0 +1,34 @@
+package dev.webauthn.samples.composepasskey.domain.signals
+
+import dev.webauthn.client.PasskeyClientError
+import dev.webauthn.client.PasskeyResult
+import dev.webauthn.model.RpId
+import dev.webauthn.model.UserHandle
+
+internal interface CredentialSignalDemoClient {
+    val isAvailable: Boolean
+
+    suspend fun signalCurrentUserDetails(
+        rpId: RpId,
+        userId: UserHandle,
+        name: String,
+        displayName: String,
+    ): PasskeyResult<Unit>
+}
+
+internal class UnsupportedCredentialSignalDemoClient : CredentialSignalDemoClient {
+    override val isAvailable: Boolean = false
+
+    override suspend fun signalCurrentUserDetails(
+        rpId: RpId,
+        userId: UserHandle,
+        name: String,
+        displayName: String,
+    ): PasskeyResult<Unit> {
+        return PasskeyResult.Failure(
+            PasskeyClientError.Platform(
+                "Credential signals are not wired for this platform in the KMP sample.",
+            ),
+        )
+    }
+}

--- a/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/domain/signals/RememberCredentialSignalDemoClient.kt
+++ b/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/domain/signals/RememberCredentialSignalDemoClient.kt
@@ -1,0 +1,6 @@
+package dev.webauthn.samples.composepasskey.domain.signals
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal expect fun rememberCredentialSignalDemoClient(): CredentialSignalDemoClient

--- a/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/screens/auth/AuthRoute.kt
+++ b/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/screens/auth/AuthRoute.kt
@@ -31,6 +31,7 @@ import dev.webauthn.samples.composepasskey.domain.passkey.areCeremonyActionsEnab
 import dev.webauthn.samples.composepasskey.domain.passkey.toAuthenticationStartPayload
 import dev.webauthn.samples.composepasskey.domain.passkey.toDemoStatus
 import dev.webauthn.samples.composepasskey.domain.passkey.toRegistrationStartPayload
+import dev.webauthn.samples.composepasskey.domain.signals.CredentialSignalDemoClient
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 
@@ -41,12 +42,18 @@ internal fun AuthRoute() {
     val debugLogs: DebugLogStore = koinInject()
     val sessionStore: AppSessionStore = koinInject()
     val passkeyClient: PasskeyClient = koinInject()
+    val credentialSignalClient: CredentialSignalDemoClient = koinInject()
     val backend: DemoPasskeyBackend = koinInject()
     // docs-region compose-sample-auth-route
     val flow = rememberPasskeyFlow(passkeyClient)
     val scope = rememberCoroutineScope()
-    val coordinator = remember(config, debugLogs, sessionStore) {
-        AuthDemoCoordinator(config, debugLogs, sessionStore)
+    val coordinator = remember(config, debugLogs, sessionStore, credentialSignalClient) {
+        AuthDemoCoordinator(
+            config = config,
+            debugLogs = debugLogs,
+            sessionStore = sessionStore,
+            credentialSignalClient = credentialSignalClient,
+        )
     }
     var state by remember { mutableStateOf<DemoCeremonyState>(DemoCeremonyState.Idle) }
     val canRegister by coordinator.canRegister.collectAsState()

--- a/sample/compose-passkey/src/commonTest/kotlin/dev/webauthn/samples/composepasskey/PasskeyDemoStateTest.kt
+++ b/sample/compose-passkey/src/commonTest/kotlin/dev/webauthn/samples/composepasskey/PasskeyDemoStateTest.kt
@@ -6,6 +6,9 @@ import dev.webauthn.client.PasskeyCapabilities
 import dev.webauthn.client.PasskeyCapability
 import dev.webauthn.client.PasskeyPhase
 import dev.webauthn.client.PlatformCapability
+import dev.webauthn.client.PasskeyResult
+import dev.webauthn.model.RpId
+import dev.webauthn.model.UserHandle
 import dev.webauthn.samples.composepasskey.app.auth.AuthDemoCoordinator
 import dev.webauthn.samples.composepasskey.data.logging.DebugLogStore
 import dev.webauthn.samples.composepasskey.data.session.AppSessionState
@@ -22,6 +25,8 @@ import dev.webauthn.samples.composepasskey.domain.passkey.PasskeyDemoConfig
 import dev.webauthn.samples.composepasskey.ui.screens.auth.canStartConditionalRegistration
 import dev.webauthn.samples.composepasskey.ui.screens.auth.canStartExplicitRegistration
 import dev.webauthn.samples.composepasskey.ui.screens.auth.supportsConditionalCreate
+import dev.webauthn.samples.composepasskey.domain.signals.CredentialSignalDemoClient
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -117,9 +122,10 @@ class PasskeyDemoStateTest {
     }
 
     @Test
-    fun coordinator_logs_actions_and_promotes_sign_in_to_app_session() {
+    fun coordinator_logs_actions_promotes_session_and_signals_current_user() = runTest {
         val logs = DebugLogStore()
         val sessions = AppSessionStore()
+        val credentialSignals = FakeCredentialSignalDemoClient()
         val coordinator = AuthDemoCoordinator(
             config = PasskeyDemoConfig(
                 endpointBase = "https://example.test",
@@ -130,6 +136,7 @@ class PasskeyDemoStateTest {
             ),
             debugLogs = logs,
             sessionStore = sessions,
+            credentialSignalClient = credentialSignals,
         )
 
         coordinator.onSignInClicked()
@@ -138,5 +145,29 @@ class PasskeyDemoStateTest {
         assertEquals(AppSessionState.SignedIn("demo@local"), sessions.state.value)
         assertTrue(logs.entries.any { it.source == "action" && it.message.contains("Sign In tapped") })
         assertTrue(logs.entries.any { it.source == "flow" && it.message.contains("Sign In success") })
+        assertTrue(logs.entries.any { it.source == "signals" && it.message.contains("accepted") })
+        assertEquals(1, credentialSignals.currentUserDetailsCalls)
+        assertEquals("example.test", credentialSignals.lastRpId?.value)
+        assertEquals("ZGVtby11c2Vy", credentialSignals.lastUserId?.value?.encoded())
+    }
+}
+
+private class FakeCredentialSignalDemoClient : CredentialSignalDemoClient {
+    var currentUserDetailsCalls: Int = 0
+    var lastRpId: RpId? = null
+    var lastUserId: UserHandle? = null
+
+    override val isAvailable: Boolean = true
+
+    override suspend fun signalCurrentUserDetails(
+        rpId: RpId,
+        userId: UserHandle,
+        name: String,
+        displayName: String,
+    ): PasskeyResult<Unit> {
+        currentUserDetailsCalls += 1
+        lastRpId = rpId
+        lastUserId = userId
+        return PasskeyResult.Success(Unit)
     }
 }

--- a/sample/compose-passkey/src/iosMain/kotlin/dev/webauthn/samples/composepasskey/MainViewController.kt
+++ b/sample/compose-passkey/src/iosMain/kotlin/dev/webauthn/samples/composepasskey/MainViewController.kt
@@ -2,10 +2,21 @@ package dev.webauthn.samples.composepasskey
 
 import androidx.compose.ui.window.ComposeUIViewController
 import dev.webauthn.samples.composepasskey.app.App
+import dev.webauthn.samples.composepasskey.domain.signals.IosBridgeCredentialSignalDemoClient
+import dev.webauthn.samples.composepasskey.domain.signals.IosCredentialSignalBridge
+import dev.webauthn.samples.composepasskey.domain.signals.UnsupportedCredentialSignalDemoClient
 
-fun MainViewController() = ComposeUIViewController(
+fun MainViewController(
+    credentialSignalBridge: IosCredentialSignalBridge? = null,
+) = ComposeUIViewController(
     configure = {
         // Keep the sample app runnable even when host apps use generated plist settings.
         enforceStrictPlistSanityCheck = false
     },
-) { App() }
+) {
+    App(
+        credentialSignalClient = credentialSignalBridge
+            ?.let(::IosBridgeCredentialSignalDemoClient)
+            ?: UnsupportedCredentialSignalDemoClient(),
+    )
+}

--- a/sample/compose-passkey/src/iosMain/kotlin/dev/webauthn/samples/composepasskey/domain/signals/IosCredentialSignalBridge.kt
+++ b/sample/compose-passkey/src/iosMain/kotlin/dev/webauthn/samples/composepasskey/domain/signals/IosCredentialSignalBridge.kt
@@ -1,0 +1,64 @@
+package dev.webauthn.samples.composepasskey.domain.signals
+
+import dev.webauthn.client.PasskeyClientError
+import dev.webauthn.client.PasskeyResult
+import dev.webauthn.model.RpId
+import dev.webauthn.model.UserHandle
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+/**
+ * Swift-implemented bridge for iOS credential-manager sync reports.
+ *
+ * Kotlin/Native does not currently expose Swift-only `ASCredentialDataManager` in
+ * `platform.AuthenticationServices`, so the iOS host app owns that call and adapts it here.
+ */
+interface IosCredentialSignalBridge {
+    val isAvailable: Boolean
+
+    /** Reports the updated name; [displayName] is unused because Apple's API has no such field. */
+    fun reportCurrentUserDetails(
+        relyingPartyIdentifier: String,
+        userHandleBase64Url: String,
+        name: String,
+        displayName: String,
+        completion: (String?) -> Unit,
+    )
+}
+
+internal class IosBridgeCredentialSignalDemoClient(
+    private val bridge: IosCredentialSignalBridge,
+) : CredentialSignalDemoClient {
+    override val isAvailable: Boolean
+        get() = bridge.isAvailable
+
+    override suspend fun signalCurrentUserDetails(
+        rpId: RpId,
+        userId: UserHandle,
+        name: String,
+        displayName: String,
+    ): PasskeyResult<Unit> {
+        if (!bridge.isAvailable) {
+            return PasskeyResult.Failure(
+                PasskeyClientError.Platform("iOS credential signals require iOS 26.2+ ASCredentialDataManager."),
+            )
+        }
+        return suspendCancellableCoroutine { continuation ->
+            bridge.reportCurrentUserDetails(
+                relyingPartyIdentifier = rpId.value,
+                userHandleBase64Url = userId.value.encoded(),
+                name = name,
+                displayName = displayName,
+            ) { errorMessage ->
+                if (!continuation.isActive) return@reportCurrentUserDetails
+                continuation.resume(
+                    if (errorMessage == null) {
+                        PasskeyResult.Success(Unit)
+                    } else {
+                        PasskeyResult.Failure(PasskeyClientError.Platform(errorMessage))
+                    },
+                )
+            }
+        }
+    }
+}

--- a/sample/compose-passkey/src/iosMain/kotlin/dev/webauthn/samples/composepasskey/domain/signals/RememberCredentialSignalDemoClient.ios.kt
+++ b/sample/compose-passkey/src/iosMain/kotlin/dev/webauthn/samples/composepasskey/domain/signals/RememberCredentialSignalDemoClient.ios.kt
@@ -1,0 +1,9 @@
+package dev.webauthn.samples.composepasskey.domain.signals
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+
+@Composable
+internal actual fun rememberCredentialSignalDemoClient(): CredentialSignalDemoClient {
+    return remember { UnsupportedCredentialSignalDemoClient() }
+}

--- a/sample/compose-passkey/src/iosTest/kotlin/dev/webauthn/samples/composepasskey/IosCredentialSignalBridgeTest.kt
+++ b/sample/compose-passkey/src/iosTest/kotlin/dev/webauthn/samples/composepasskey/IosCredentialSignalBridgeTest.kt
@@ -1,0 +1,90 @@
+package dev.webauthn.samples.composepasskey
+
+import dev.webauthn.client.PasskeyResult
+import dev.webauthn.model.RpId
+import dev.webauthn.model.UserHandle
+import dev.webauthn.samples.composepasskey.domain.signals.IosBridgeCredentialSignalDemoClient
+import dev.webauthn.samples.composepasskey.domain.signals.IosCredentialSignalBridge
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class IosCredentialSignalBridgeTest {
+    @Test
+    fun signalCurrentUserDetails_forwards_values_toSwiftBridge() = runBlocking {
+        val bridge = FakeIosCredentialSignalBridge()
+        val client = IosBridgeCredentialSignalDemoClient(bridge)
+
+        val result = client.signalCurrentUserDetails(
+            rpId = RpId.parseOrThrow("example.com"),
+            userId = UserHandle.fromBytes("demo-user".encodeToByteArray()),
+            name = "demo",
+            displayName = "Demo User",
+        )
+
+        assertTrue(result is PasskeyResult.Success)
+        assertEquals("example.com", bridge.lastRelyingPartyIdentifier)
+        assertEquals("ZGVtby11c2Vy", bridge.lastUserHandleBase64Url)
+        assertEquals("demo", bridge.lastName)
+        assertEquals("Demo User", bridge.lastDisplayName)
+    }
+
+    @Test
+    fun signalCurrentUserDetails_returnsFailure_whenBridgeIsUnavailable() = runBlocking {
+        val client = IosBridgeCredentialSignalDemoClient(
+            FakeIosCredentialSignalBridge(isAvailable = false),
+        )
+
+        val result = client.signalCurrentUserDetails(
+            rpId = RpId.parseOrThrow("example.com"),
+            userId = UserHandle.fromBytes("demo-user".encodeToByteArray()),
+            name = "demo",
+            displayName = "Demo User",
+        )
+
+        assertTrue(result is PasskeyResult.Failure)
+        assertTrue(result.error.message.contains("iOS 26.2+"))
+    }
+
+    @Test
+    fun signalCurrentUserDetails_returnsFailure_whenBridgeReportsError() = runBlocking {
+        val client = IosBridgeCredentialSignalDemoClient(
+            FakeIosCredentialSignalBridge(errorMessage = "ASCredentialDataManager failed"),
+        )
+
+        val result = client.signalCurrentUserDetails(
+            rpId = RpId.parseOrThrow("example.com"),
+            userId = UserHandle.fromBytes("demo-user".encodeToByteArray()),
+            name = "demo",
+            displayName = "Demo User",
+        )
+
+        assertTrue(result is PasskeyResult.Failure)
+        assertEquals("ASCredentialDataManager failed", result.error.message)
+    }
+
+    private class FakeIosCredentialSignalBridge(
+        override val isAvailable: Boolean = true,
+        private val errorMessage: String? = null,
+    ) : IosCredentialSignalBridge {
+        var lastRelyingPartyIdentifier: String? = null
+        var lastUserHandleBase64Url: String? = null
+        var lastName: String? = null
+        var lastDisplayName: String? = null
+
+        override fun reportCurrentUserDetails(
+            relyingPartyIdentifier: String,
+            userHandleBase64Url: String,
+            name: String,
+            displayName: String,
+            completion: (String?) -> Unit,
+        ) {
+            lastRelyingPartyIdentifier = relyingPartyIdentifier
+            lastUserHandleBase64Url = userHandleBase64Url
+            lastName = name
+            lastDisplayName = displayName
+            completion(errorMessage)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `AndroidCredentialSignalClient` to `webauthn-client-platform`'s Android source set.
- Expose typed helpers for accepted credential IDs, unknown credentials, and current-user details using `RpId`, `UserHandle`, `CredentialId`, and `Origin`.
- Document best-effort provider signaling semantics and the privileged-only `origin` override.
- Map platform `SecurityException` failures into stable client errors.
- Report current-user details after successful sign-in in the final `PasskeyFlow`-based Compose sample.
- Demonstrate Apple's analogous iOS 26.2+ API through a sample-owned Swift `ASCredentialDataManager` bridge.

## Why

Credential-state signals let relying parties help enabled passkey providers reconcile account and credential changes. They remain best-effort hints: the server is authoritative, and successful submission does not prove that every provider applied an update.

The published implementation is Android-specific because AndroidX Credential Manager exposes the API directly to Kotlin. Apple's current API is Swift-only, so the reusable KMP artifact does not pretend to provide a Kotlin/Native implementation; the iOS sample demonstrates the host-owned bridge explicitly.

## Origin boundary

Ordinary Android applications leave `origin` unset. The override is only for browsers or similarly privileged applications acting for another application, and Android 14+ requires `android.permission.CREDENTIAL_MANAGER_SET_ORIGIN`. The API KDoc and module README state this at every public entry point.

## Architecture and sample behavior

- Android implementation: `webauthn-client-platform/src/androidMain`.
- Android regression coverage: `webauthn-client-platform/src/androidHostTest`.
- Inputs/results remain codec-neutral; no Kotlinx implementation dependency is introduced.
- Compose orchestration remains on the generic backend/opaque-state `PasskeyFlow` architecture.
- The iOS bridge stays sample-owned and injectable from the Swift host.
- The demo reports current-user details only; it does not fabricate all-accepted or unknown-credential signals without an authoritative inventory/failure path.

## Validation on the rewritten head

- `./gradlew docsUpdate :client:webauthn-client-platform:testAndroidHostTest :sample:compose-passkey:allTests --stacktrace`
- `./gradlew apiCheck --stacktrace`
- `tools/agent/quality-gate.sh --mode strict --scope changed --block false`
- `git diff --check`

The strict gate includes documentation verification, static analysis, and the iOS simulator host build. No physical iOS-device smoke test is claimed.

## Stack

This PR is one signal-specific commit on #172, which is one restore-specific commit on #170. The stack is based on current dependency-updated `main`.
