### PR TITLE
sample(ios): add credential signal Swift bridge

### DIFF
--- a/sample/compose-passkey-ios/ComposePasskeyIos.xcodeproj/project.pbxproj
+++ b/sample/compose-passkey-ios/ComposePasskeyIos.xcodeproj/project.pbxproj
@@ -10,10 +10,12 @@
 		285CB960E67F5D7493B47868 /* ComposePasskeyIosApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A72121BAA5A0037AE74FEA /* ComposePasskeyIosApp.swift */; };
 		729ECCE037B334E608061C3B /* ComposePasskeyShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 020E8BEC08EDAB193162C8F0 /* ComposePasskeyShared.framework */; };
 		EEA0A397E433A3BC1D8E6F51 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D05536FE2830CD3C83D94EDF /* Assets.xcassets */; };
+		F2EC0E427B8EA5AE159C950D /* IosCredentialSignalBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0213E5FA8F185AD766C9B2D /* IosCredentialSignalBridge.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		020E8BEC08EDAB193162C8F0 /* ComposePasskeyShared.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ComposePasskeyShared.framework; path = "$SRCROOT/../compose-passkey/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)/ComposePasskeyShared.framework"; sourceTree = "<group>"; };
+		A0213E5FA8F185AD766C9B2D /* IosCredentialSignalBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IosCredentialSignalBridge.swift; sourceTree = "<group>"; };
 		D05536FE2830CD3C83D94EDF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		EC8470A115D06D044F4D7D79 /* ComposePasskeyIos.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ComposePasskeyIos.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F3A72121BAA5A0037AE74FEA /* ComposePasskeyIosApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposePasskeyIosApp.swift; sourceTree = "<group>"; };
@@ -45,6 +47,7 @@
 			children = (
 				D05536FE2830CD3C83D94EDF /* Assets.xcassets */,
 				F3A72121BAA5A0037AE74FEA /* ComposePasskeyIosApp.swift */,
+				A0213E5FA8F185AD766C9B2D /* IosCredentialSignalBridge.swift */,
 			);
 			path = ComposePasskeyIos;
 			sourceTree = "<group>";
@@ -158,6 +161,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				285CB960E67F5D7493B47868 /* ComposePasskeyIosApp.swift in Sources */,
+				F2EC0E427B8EA5AE159C950D /* IosCredentialSignalBridge.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/sample/compose-passkey-ios/ComposePasskeyIos/ComposePasskeyIosApp.swift
+++ b/sample/compose-passkey-ios/ComposePasskeyIos/ComposePasskeyIosApp.swift
@@ -30,7 +30,9 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
 
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = MainViewControllerKt.MainViewController()
+        window.rootViewController = MainViewControllerKt.MainViewController(
+            credentialSignalBridge: AuthenticationServicesCredentialSignalBridge(),
+        )
         self.window = window
         window.makeKeyAndVisible()
     }

--- a/sample/compose-passkey-ios/ComposePasskeyIos/IosCredentialSignalBridge.swift
+++ b/sample/compose-passkey-ios/ComposePasskeyIos/IosCredentialSignalBridge.swift
@@ -1,0 +1,69 @@
+import AuthenticationServices
+import ComposePasskeyShared
+import Foundation
+
+final class AuthenticationServicesCredentialSignalBridge: ComposePasskeyShared.IosCredentialSignalBridge {
+    var isAvailable: Bool {
+        if #available(iOS 26.2, *) {
+            return true
+        }
+        return false
+    }
+
+    func reportCurrentUserDetails(
+        relyingPartyIdentifier: String,
+        userHandleBase64Url: String,
+        name: String,
+        displayName: String,
+        completion: @escaping (String?) -> Void,
+    ) {
+        guard let userHandle = Data(base64URLEncoded: userHandleBase64Url) else {
+            completion("Invalid base64url user handle for iOS credential signal.")
+            return
+        }
+
+        if #available(iOS 26.2, *) {
+            let completionBox = CredentialSignalCompletionBox(completion)
+            Task {
+                do {
+                    try await ASCredentialDataManager().reportPublicKeyCredentialUpdate(
+                        relyingPartyIdentifier: relyingPartyIdentifier,
+                        userHandle: userHandle,
+                        newName: name,
+                    )
+                    await completionBox.complete(nil)
+                } catch {
+                    await completionBox.complete(error.localizedDescription)
+                }
+            }
+        } else {
+            completion("iOS credential signals require iOS 26.2+ ASCredentialDataManager.")
+        }
+    }
+}
+
+private final class CredentialSignalCompletionBox: @unchecked Sendable {
+    private let completion: (String?) -> Void
+
+    init(_ completion: @escaping (String?) -> Void) {
+        self.completion = completion
+    }
+
+    @MainActor
+    func complete(_ errorMessage: String?) {
+        completion(errorMessage)
+    }
+}
+
+private extension Data {
+    init?(base64URLEncoded value: String) {
+        var base64 = value
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let padding = base64.count % 4
+        if padding > 0 {
+            base64.append(String(repeating: "=", count: 4 - padding))
+        }
+        self.init(base64Encoded: base64)
+    }
+}

--- a/sample/compose-passkey-ios/README.md
+++ b/sample/compose-passkey-ios/README.md
@@ -9,6 +9,7 @@ Use this sample when you want to run the passkey demo on a connected iPhone from
 - A committed Xcode app project (`ComposePasskeyIos.xcodeproj`).
 - SwiftUI app shell that mounts Kotlin `MainViewController()` from `sample:compose-passkey`.
 - Build phase script that runs `:sample:compose-passkey:embedAndSignAppleFrameworkForXcode`.
+- Swift bridge for iOS credential signals using `ASCredentialDataManager` when running on iOS 26.2+.
 
 ## Quick run on device (free Apple account)
 
@@ -63,6 +64,19 @@ Expected result:
 - `Sign In` completes.
 - Signed-in extension demo screen is shown after successful sign-in.
 - `PasskeyDemo` logs appear in Xcode console and in the hidden in-app debug sheet (title double-tap).
+- On iOS 26.2+, the app reports the signed-in user name to AuthenticationServices through the Swift credential-signal bridge.
+
+## iOS credential signal bridge
+
+The shared Kotlin module exports `IosCredentialSignalBridge` because Kotlin/Native does not currently
+expose Swift-only `ASCredentialDataManager` bindings under `platform.AuthenticationServices`.
+`AuthenticationServicesCredentialSignalBridge` implements that protocol in Swift and is passed into
+`MainViewController(...)` by the host app.
+
+Availability expectations:
+
+- iOS 26.2+: `reportPublicKeyCredentialUpdate(...)` is called after successful sign-in.
+- Older iOS versions: the bridge reports unavailable and the sample logs that credential signals require iOS 26.2+.
 
 ## Environment variables used by the shared sample
 

--- a/sample/compose-passkey/README.md
+++ b/sample/compose-passkey/README.md
@@ -149,8 +149,9 @@ exposes that state.
 
 On iOS, Apple exposes the analogous `ASCredentialDataManager` sync reports from Swift, but the
 current Kotlin/Native SDK bindings do not expose that Swift-only type under
-`platform.AuthenticationServices`. The iOS sample actual therefore remains an explicit unsupported
-client until the app adds a native Swift shim or Kotlin/Native exposes the API directly.
+`platform.AuthenticationServices`. The committed iOS host app therefore injects a tiny Swift
+`IosCredentialSignalBridge` implementation into `MainViewController(...)`; Kotlin owns the sample
+flow, while Swift owns the iOS 26.2+ AuthenticationServices call.
 
 ## Compose previews
 

--- a/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/app/App.kt
+++ b/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/app/App.kt
@@ -11,6 +11,7 @@ import dev.webauthn.samples.composepasskey.data.network.DemoPasskeyServerClient
 import dev.webauthn.samples.composepasskey.data.network.normalizedEndpoint
 import dev.webauthn.samples.composepasskey.data.network.rememberPlatformHttpClient
 import dev.webauthn.samples.composepasskey.domain.passkey.PasskeyDemoConfig
+import dev.webauthn.samples.composepasskey.domain.signals.CredentialSignalDemoClient
 import dev.webauthn.samples.composepasskey.domain.signals.rememberCredentialSignalDemoClient
 import kotlinx.coroutines.launch
 import org.koin.compose.KoinApplication
@@ -19,6 +20,13 @@ import org.koin.dsl.koinConfiguration
 
 @Composable
 fun App() {
+    App(credentialSignalClient = rememberCredentialSignalDemoClient())
+}
+
+@Composable
+internal fun App(
+    credentialSignalClient: CredentialSignalDemoClient,
+) {
     val scope = rememberCoroutineScope()
     val debugLogs = remember { DebugLogStore() }
     val httpLogSink: (String) -> Unit = remember(scope, debugLogs) {
@@ -27,7 +35,6 @@ fun App() {
     val httpClient = rememberPlatformHttpClient(onLogLine = httpLogSink)
     val config = remember { PasskeyDemoConfig() }
     val passkeyClient = rememberPasskeyClient()
-    val credentialSignalClient = rememberCredentialSignalDemoClient()
     val serverClient: DemoPasskeyServerClient = remember(httpClient, config.endpointBase) {
         KtorPasskeyServerClient(
             httpClient = httpClient,

--- a/sample/compose-passkey/src/iosMain/kotlin/dev/webauthn/samples/composepasskey/MainViewController.kt
+++ b/sample/compose-passkey/src/iosMain/kotlin/dev/webauthn/samples/composepasskey/MainViewController.kt
@@ -2,10 +2,21 @@ package dev.webauthn.samples.composepasskey
 
 import androidx.compose.ui.window.ComposeUIViewController
 import dev.webauthn.samples.composepasskey.app.App
+import dev.webauthn.samples.composepasskey.domain.signals.IosBridgeCredentialSignalDemoClient
+import dev.webauthn.samples.composepasskey.domain.signals.IosCredentialSignalBridge
+import dev.webauthn.samples.composepasskey.domain.signals.UnsupportedCredentialSignalDemoClient
 
-fun MainViewController() = ComposeUIViewController(
+fun MainViewController(
+    credentialSignalBridge: IosCredentialSignalBridge? = null,
+) = ComposeUIViewController(
     configure = {
         // Keep the sample app runnable even when host apps use generated plist settings.
         enforceStrictPlistSanityCheck = false
     },
-) { App() }
+) {
+    App(
+        credentialSignalClient = credentialSignalBridge
+            ?.let(::IosBridgeCredentialSignalDemoClient)
+            ?: UnsupportedCredentialSignalDemoClient(),
+    )
+}

--- a/sample/compose-passkey/src/iosMain/kotlin/dev/webauthn/samples/composepasskey/domain/signals/IosCredentialSignalBridge.kt
+++ b/sample/compose-passkey/src/iosMain/kotlin/dev/webauthn/samples/composepasskey/domain/signals/IosCredentialSignalBridge.kt
@@ -1,0 +1,63 @@
+package dev.webauthn.samples.composepasskey.domain.signals
+
+import dev.webauthn.client.PasskeyClientError
+import dev.webauthn.client.PasskeyResult
+import dev.webauthn.model.RpId
+import dev.webauthn.model.UserHandle
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+/**
+ * Swift-implemented bridge for iOS credential-manager sync reports.
+ *
+ * Kotlin/Native does not currently expose Swift-only `ASCredentialDataManager` in
+ * `platform.AuthenticationServices`, so the iOS host app owns that call and adapts it here.
+ */
+interface IosCredentialSignalBridge {
+    val isAvailable: Boolean
+
+    fun reportCurrentUserDetails(
+        relyingPartyIdentifier: String,
+        userHandleBase64Url: String,
+        name: String,
+        displayName: String,
+        completion: (String?) -> Unit,
+    )
+}
+
+internal class IosBridgeCredentialSignalDemoClient(
+    private val bridge: IosCredentialSignalBridge,
+) : CredentialSignalDemoClient {
+    override val isAvailable: Boolean
+        get() = bridge.isAvailable
+
+    override suspend fun signalCurrentUserDetails(
+        rpId: RpId,
+        userId: UserHandle,
+        name: String,
+        displayName: String,
+    ): PasskeyResult<Unit> {
+        if (!bridge.isAvailable) {
+            return PasskeyResult.Failure(
+                PasskeyClientError.Platform("iOS credential signals require iOS 26.2+ ASCredentialDataManager."),
+            )
+        }
+        return suspendCancellableCoroutine { continuation ->
+            bridge.reportCurrentUserDetails(
+                relyingPartyIdentifier = rpId.value,
+                userHandleBase64Url = userId.value.encoded(),
+                name = name,
+                displayName = displayName,
+            ) { errorMessage ->
+                if (!continuation.isActive) return@reportCurrentUserDetails
+                continuation.resume(
+                    if (errorMessage == null) {
+                        PasskeyResult.Success(Unit)
+                    } else {
+                        PasskeyResult.Failure(PasskeyClientError.Platform(errorMessage))
+                    },
+                )
+            }
+        }
+    }
+}

--- a/sample/compose-passkey/src/iosTest/kotlin/dev/webauthn/samples/composepasskey/IosCredentialSignalBridgeTest.kt
+++ b/sample/compose-passkey/src/iosTest/kotlin/dev/webauthn/samples/composepasskey/IosCredentialSignalBridgeTest.kt
@@ -1,0 +1,90 @@
+package dev.webauthn.samples.composepasskey
+
+import dev.webauthn.client.PasskeyResult
+import dev.webauthn.model.RpId
+import dev.webauthn.model.UserHandle
+import dev.webauthn.samples.composepasskey.domain.signals.IosBridgeCredentialSignalDemoClient
+import dev.webauthn.samples.composepasskey.domain.signals.IosCredentialSignalBridge
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class IosCredentialSignalBridgeTest {
+    @Test
+    fun signalCurrentUserDetails_forwards_values_toSwiftBridge() = runBlocking {
+        val bridge = FakeIosCredentialSignalBridge()
+        val client = IosBridgeCredentialSignalDemoClient(bridge)
+
+        val result = client.signalCurrentUserDetails(
+            rpId = RpId.parseOrThrow("example.com"),
+            userId = UserHandle.fromBytes("demo-user".encodeToByteArray()),
+            name = "demo",
+            displayName = "Demo User",
+        )
+
+        assertTrue(result is PasskeyResult.Success)
+        assertEquals("example.com", bridge.lastRelyingPartyIdentifier)
+        assertEquals("ZGVtby11c2Vy", bridge.lastUserHandleBase64Url)
+        assertEquals("demo", bridge.lastName)
+        assertEquals("Demo User", bridge.lastDisplayName)
+    }
+
+    @Test
+    fun signalCurrentUserDetails_returnsFailure_whenBridgeIsUnavailable() = runBlocking {
+        val client = IosBridgeCredentialSignalDemoClient(
+            FakeIosCredentialSignalBridge(isAvailable = false),
+        )
+
+        val result = client.signalCurrentUserDetails(
+            rpId = RpId.parseOrThrow("example.com"),
+            userId = UserHandle.fromBytes("demo-user".encodeToByteArray()),
+            name = "demo",
+            displayName = "Demo User",
+        )
+
+        assertTrue(result is PasskeyResult.Failure)
+        assertTrue(result.error.message.contains("iOS 26.2+"))
+    }
+
+    @Test
+    fun signalCurrentUserDetails_returnsFailure_whenBridgeReportsError() = runBlocking {
+        val client = IosBridgeCredentialSignalDemoClient(
+            FakeIosCredentialSignalBridge(errorMessage = "ASCredentialDataManager failed"),
+        )
+
+        val result = client.signalCurrentUserDetails(
+            rpId = RpId.parseOrThrow("example.com"),
+            userId = UserHandle.fromBytes("demo-user".encodeToByteArray()),
+            name = "demo",
+            displayName = "Demo User",
+        )
+
+        assertTrue(result is PasskeyResult.Failure)
+        assertEquals("ASCredentialDataManager failed", result.error.message)
+    }
+
+    private class FakeIosCredentialSignalBridge(
+        override val isAvailable: Boolean = true,
+        private val errorMessage: String? = null,
+    ) : IosCredentialSignalBridge {
+        var lastRelyingPartyIdentifier: String? = null
+        var lastUserHandleBase64Url: String? = null
+        var lastName: String? = null
+        var lastDisplayName: String? = null
+
+        override fun reportCurrentUserDetails(
+            relyingPartyIdentifier: String,
+            userHandleBase64Url: String,
+            name: String,
+            displayName: String,
+            completion: (String?) -> Unit,
+        ) {
+            lastRelyingPartyIdentifier = relyingPartyIdentifier
+            lastUserHandleBase64Url = userHandleBase64Url
+            lastName = name
+            lastDisplayName = displayName
+            completion(errorMessage)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- exports a small Kotlin `IosCredentialSignalBridge` protocol from the shared sample module
- implements the protocol in the iOS host app with Swift `ASCredentialDataManager`
- injects the Swift bridge into `MainViewController(...)` so the sample can report current-user credential updates on iOS 26.2+

## Why this is a separate PR
Kotlin/Native does not currently expose Swift-only `ASCredentialDataManager` under `platform.AuthenticationServices`, so the KMP library cannot call it directly. The narrow bridge keeps #171 focused on the Android library API while showing the native iOS integration path in the sample host.

## Verification
- `./gradlew :sample:compose-passkey:iosSimulatorArm64Test --tests dev.webauthn.samples.composepasskey.IosCredentialSignalBridgeTest :sample:compose-passkey:compileKotlinIosSimulatorArm64 --stacktrace`
- `xcodebuildmcp simulator build --project-path sample/compose-passkey-ios/ComposePasskeyIos.xcodeproj --scheme ComposePasskeyIos --configuration Debug --simulator-id 353A5736-2ED4-42B8-ADC0-54526CCDB062 --derived-data-path /tmp/webauthn-compose-passkey-ios-derived`
- `tools/agent/quality-gate.sh --mode strict --scope changed --block false`
- `git diff --check`