### PR TITLE
ci: add FIDO registration compatibility canary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,22 @@ jobs:
       - name: JVM Checks
         run: ./gradlew check --stacktrace
 
+  fido-registration-compatibility:
+    runs-on: ubuntu-latest
+    needs: [harness]
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+      - uses: gradle/actions/setup-gradle@v6
+      - name: FIDO Server Registration Compatibility Canary
+        run: ./gradlew :sample:backend-ktor:communityConformanceE2eTest --stacktrace
+
   documentation:
     runs-on: macos-26
     needs: [harness]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,22 @@ jobs:
       - name: JVM Checks
         run: ./gradlew check --stacktrace
 
+  fido-registration-compatibility:
+    runs-on: ubuntu-latest
+    needs: [harness]
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+      - uses: gradle/actions/setup-gradle@v6
+      - name: FIDO Server Registration Compatibility Canary
+        run: ./gradlew :sample:backend-ktor:communityConformanceE2eTest --stacktrace
+
   documentation:
     runs-on: macos-26
     needs: [harness]

--- a/documentation/example-inventory.md
+++ b/documentation/example-inventory.md
@@ -4,7 +4,7 @@
 This inventory is generated from the inline `doc-example` directives. It records every user-facing fenced
 example, its single source of truth, and its strongest automated or illustrative verification level.
 
-Managed blocks: **135**
+Managed blocks: **136**
 
 | ID | File | Purpose | Language | Audience | Owner | Source of truth | Verification | Exception |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -108,8 +108,9 @@ Managed blocks: **135**
 | docs-wiki-quality-and-release-bash-1 | docs/wiki/quality-and-release.md:12 | Default Quality Gates | bash | contributor | markdown | Markdown block | syntax |  |
 | platform-bom-readme-kotlin-1 | platform/bom/README.md:25 | How to use | kotlin | consumer | configuration | documentation/consumer-smoke/server/build.gradle.kts.template#consumer-server-dependencies | consumer-compile |  |
 | platform-bom-readme-mermaid-1 | platform/bom/README.md:38 | Fit in the system | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
-| sample-backend-ktor-readme-bash-1 | sample/backend-ktor/README.md:20 | Run | bash | consumer | markdown | Markdown block | syntax |  |
-| sample-backend-ktor-readme-bash-2 | sample/backend-ktor/README.md:45 | ngrok helper | bash | consumer | markdown | Markdown block | syntax |  |
+| sample-backend-ktor-readme-bash-1 | sample/backend-ktor/README.md:22 | Run | bash | consumer | markdown | Markdown block | syntax |  |
+| sample-backend-ktor-readme-bash-3 | sample/backend-ktor/README.md:61 | FIDO server registration compatibility canary | bash | contributor | markdown | Markdown block | syntax |  |
+| sample-backend-ktor-readme-bash-2 | sample/backend-ktor/README.md:70 | ngrok helper | bash | consumer | markdown | Markdown block | syntax |  |
 | sample-compose-passkey-ios-readme-bash-1 | sample/compose-passkey-ios/README.md:20 | Quick run on a device with a free Apple account | bash | consumer | markdown | Markdown block | syntax |  |
 | sample-compose-passkey-ios-readme-bash-2 | sample/compose-passkey-ios/README.md:46 | Complete passkey path with Associated Domains | bash | consumer | markdown | Markdown block | syntax |  |
 | sample-compose-passkey-ios-readme-bash-3 | sample/compose-passkey-ios/README.md:102 | Maintaining this project | bash | contributor | markdown | Markdown block | syntax |  |

--- a/documentation/example-inventory.md
+++ b/documentation/example-inventory.md
@@ -4,7 +4,7 @@
 This inventory is generated from the inline `doc-example` directives. It records every user-facing fenced
 example, its single source of truth, and its strongest automated or illustrative verification level.
 
-Managed blocks: **111**
+Managed blocks: **112**
 
 | ID | File | Purpose | Language | Audience | Owner | Source of truth | Verification | Exception |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -84,8 +84,9 @@ Managed blocks: **111**
 | docs-wiki-quality-and-release-bash-1 | docs/wiki/quality-and-release.md:12 | Default Quality Gates | bash | contributor | markdown | Markdown block | syntax |  |
 | platform-bom-readme-kotlin-1 | platform/bom/README.md:25 | How to use | kotlin | consumer | configuration | documentation/consumer-smoke/server/build.gradle.kts.template#consumer-server-dependencies | consumer-compile |  |
 | platform-bom-readme-mermaid-1 | platform/bom/README.md:38 | Fit in the system | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
-| sample-backend-ktor-readme-bash-1 | sample/backend-ktor/README.md:20 | Run | bash | consumer | markdown | Markdown block | syntax |  |
-| sample-backend-ktor-readme-bash-2 | sample/backend-ktor/README.md:45 | ngrok helper | bash | consumer | markdown | Markdown block | syntax |  |
+| sample-backend-ktor-readme-bash-1 | sample/backend-ktor/README.md:22 | Run | bash | consumer | markdown | Markdown block | syntax |  |
+| sample-backend-ktor-readme-bash-3 | sample/backend-ktor/README.md:61 | FIDO server registration compatibility canary | bash | contributor | markdown | Markdown block | syntax |  |
+| sample-backend-ktor-readme-bash-2 | sample/backend-ktor/README.md:70 | ngrok helper | bash | consumer | markdown | Markdown block | syntax |  |
 | sample-compose-passkey-ios-readme-bash-1 | sample/compose-passkey-ios/README.md:20 | Quick run on device (free Apple account) | bash | consumer | markdown | Markdown block | syntax |  |
 | sample-compose-passkey-ios-readme-bash-2 | sample/compose-passkey-ios/README.md:46 | Full passkey E2E path (Associated Domains capable setup) | bash | consumer | markdown | Markdown block | syntax |  |
 | sample-compose-passkey-ios-readme-bash-3 | sample/compose-passkey-ios/README.md:102 | Maintaining this project | bash | contributor | markdown | Markdown block | syntax |  |

--- a/sample/backend-ktor/README.md
+++ b/sample/backend-ktor/README.md
@@ -8,6 +8,8 @@ A Ktor backend for local and mobile end-to-end passkey flows.
 - `POST /webauthn/registration/finish`
 - `POST /webauthn/authentication/start`
 - `POST /webauthn/authentication/finish`
+- `POST /attestation/options` (when the registration compatibility adapter is enabled)
+- `POST /attestation/result` (when the registration compatibility adapter is enabled)
 - `GET /health`
 - `GET /.well-known/assetlinks.json`
 - `GET /.well-known/apple-app-site-association`
@@ -30,12 +32,35 @@ Environment variables:
 - `IOS_APP_ID` (canonical iOS app ID for AASA `webcredentials.apps`, default placeholder)
 - `IOS_TEAM_ID` (optional helper input, used to derive `IOS_APP_ID` when `IOS_APP_ID` is unset)
 - `IOS_BUNDLE_ID` (optional helper input, used to derive `IOS_APP_ID` when `IOS_APP_ID` is unset)
+- `WEBAUTHN_CONFORMANCE_ENABLED` (`false` by default; set `true` only for the registration compatibility adapter)
+- `WEBAUTHN_CONFORMANCE_RP_ID` (server-controlled RP ID, default `localhost`)
+- `WEBAUTHN_CONFORMANCE_RP_NAME` (server-controlled RP display name)
+- `WEBAUTHN_CONFORMANCE_ORIGIN` (server-controlled expected origin, default `https://localhost:${PORT}`)
 
 `IOS_APP_ID` resolution:
 
 1. If `IOS_APP_ID` is set, it is used as-is.
 2. Else if both `IOS_TEAM_ID` and `IOS_BUNDLE_ID` are set, backend derives `IOS_APP_ID=${IOS_TEAM_ID}.${IOS_BUNDLE_ID}`.
 3. Else backend uses placeholder `TEAMID.com.example.app` and logs a warning.
+
+## FIDO server registration compatibility canary
+
+The optional `/attestation/options` and `/attestation/result` routes adapt the
+sample backend to the FIDO server testing API's registration payload shape. They
+are disabled by default and intentionally cover registration only; they are a
+compatibility canary, not FIDO certification or a complete conformance server.
+
+The adapter always uses `WEBAUTHN_CONFORMANCE_RP_ID`,
+`WEBAUTHN_CONFORMANCE_RP_NAME`, and `WEBAUTHN_CONFORMANCE_ORIGIN` as trusted
+server configuration. RP or origin values supplied by the caller are ignored,
+and unsupported extension input is not reflected into creation options.
+
+Run the local canary test with:
+
+<!-- doc-example: id=sample-backend-ktor-readme-bash-3; owner=markdown; verify=syntax; audience=contributor -->
+```bash
+./gradlew :sample:backend-ktor:communityConformanceE2eTest
+```
 
 ## ngrok helper
 

--- a/sample/backend-ktor/README.md
+++ b/sample/backend-ktor/README.md
@@ -8,6 +8,8 @@ Ktor sample backend for local/mobile passkey end-to-end flows.
 - `POST /webauthn/registration/finish`
 - `POST /webauthn/authentication/start`
 - `POST /webauthn/authentication/finish`
+- `POST /attestation/options` (when the registration compatibility adapter is enabled)
+- `POST /attestation/result` (when the registration compatibility adapter is enabled)
 - `GET /health`
 - `GET /.well-known/assetlinks.json`
 - `GET /.well-known/apple-app-site-association`
@@ -30,12 +32,35 @@ Environment variables:
 - `IOS_APP_ID` (canonical iOS app id for AASA `webcredentials.apps`, default placeholder)
 - `IOS_TEAM_ID` (optional helper input, used to derive `IOS_APP_ID` when `IOS_APP_ID` is unset)
 - `IOS_BUNDLE_ID` (optional helper input, used to derive `IOS_APP_ID` when `IOS_APP_ID` is unset)
+- `WEBAUTHN_CONFORMANCE_ENABLED` (`false` by default; set `true` only for the registration compatibility adapter)
+- `WEBAUTHN_CONFORMANCE_RP_ID` (server-controlled RP ID, default `localhost`)
+- `WEBAUTHN_CONFORMANCE_RP_NAME` (server-controlled RP display name)
+- `WEBAUTHN_CONFORMANCE_ORIGIN` (server-controlled expected origin, default `https://localhost:${PORT}`)
 
 `IOS_APP_ID` resolution:
 
 1. If `IOS_APP_ID` is set, it is used as-is.
 2. Else if both `IOS_TEAM_ID` and `IOS_BUNDLE_ID` are set, backend derives `IOS_APP_ID=${IOS_TEAM_ID}.${IOS_BUNDLE_ID}`.
 3. Else backend uses placeholder `TEAMID.com.example.app` and logs a warning.
+
+## FIDO server registration compatibility canary
+
+The optional `/attestation/options` and `/attestation/result` routes adapt the
+sample backend to the FIDO server testing API's registration payload shape. They
+are disabled by default and intentionally cover registration only; they are a
+compatibility canary, not FIDO certification or a complete conformance server.
+
+The adapter always uses `WEBAUTHN_CONFORMANCE_RP_ID`,
+`WEBAUTHN_CONFORMANCE_RP_NAME`, and `WEBAUTHN_CONFORMANCE_ORIGIN` as trusted
+server configuration. RP or origin values supplied by the caller are ignored,
+and unsupported extension input is not reflected into creation options.
+
+Run the local canary test with:
+
+<!-- doc-example: id=sample-backend-ktor-readme-bash-3; owner=markdown; verify=syntax; audience=contributor -->
+```bash
+./gradlew :sample:backend-ktor:communityConformanceE2eTest
+```
 
 ## ngrok helper
 

--- a/sample/backend-ktor/build.gradle.kts
+++ b/sample/backend-ktor/build.gradle.kts
@@ -19,7 +19,23 @@ dependencies {
     testImplementation(kotlin("test"))
     testImplementation(project(":server:webauthn-server-core-jvm"))
     testImplementation(project(":server:webauthn-server-jvm-crypto"))
+    testImplementation(project(":client:webauthn-client-core"))
+    testImplementation(project(":client:webauthn-client-flow"))
+    testImplementation(project(":client:webauthn-client-json-core"))
+    testImplementation(project(":client:webauthn-client-ktor-kotlinx"))
     testImplementation(libs.ktor.server.test.host)
     testImplementation(libs.ktor.client.content.negotiation)
     testImplementation(libs.ktor.serialization.kotlinx.json)
+}
+
+tasks.register<Test>("communityConformanceE2eTest") {
+    description = "Runs the FIDO server registration compatibility canary against the sample backend."
+    group = "verification"
+
+    val testTask = tasks.named<Test>("test").get()
+    testClassesDirs = testTask.testClassesDirs
+    classpath = testTask.classpath
+    filter {
+        includeTestsMatching("dev.webauthn.samples.backend.CommunityConformanceE2eTest")
+    }
 }

--- a/sample/backend-ktor/src/main/kotlin/dev/webauthn/samples/backend/CommunityConformanceParsing.kt
+++ b/sample/backend-ktor/src/main/kotlin/dev/webauthn/samples/backend/CommunityConformanceParsing.kt
@@ -1,0 +1,49 @@
+package dev.webauthn.samples.backend
+
+import dev.webauthn.model.RawRegistrationResponse
+import dev.webauthn.model.ValidationResult
+import dev.webauthn.serialization.RegistrationResponseDto
+import dev.webauthn.serialization.WebAuthnDtoMapper
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
+
+internal val conformanceJson: Json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = false
+}
+
+internal fun JsonObject.parseRawRegistrationResponse(): RawRegistrationResponse? {
+    val responseDto = runCatching { registrationResponseDto() }.getOrNull() ?: return null
+    return when (val result = WebAuthnDtoMapper.toRawModel(responseDto)) {
+        is ValidationResult.Valid -> result.value
+        is ValidationResult.Invalid -> null
+    }
+}
+
+private fun JsonObject.registrationResponseDto(): RegistrationResponseDto {
+    val credentialJson = this["response"]
+        ?.jsonObject
+        ?.takeIf { it["response"] is JsonObject }
+        ?: this
+    val normalizedCredentialJson = credentialJson.withRawIdFallback()
+    return runCatching {
+        conformanceJson.decodeFromJsonElement(RegistrationResponseDto.serializer(), normalizedCredentialJson)
+    }.getOrElse { error ->
+        throw IllegalArgumentException("Registration response payload is invalid: ${error.message}", error)
+    }
+}
+
+private fun JsonObject.withRawIdFallback(): JsonObject {
+    if ("rawId" in this) {
+        return this
+    }
+    val id = stringValue("id") ?: return this
+    return buildJsonObject {
+        this@withRawIdFallback.forEach { (key, value) -> put(key, value) }
+        put("rawId", id)
+    }
+}

--- a/sample/backend-ktor/src/main/kotlin/dev/webauthn/samples/backend/CommunityConformancePayloads.kt
+++ b/sample/backend-ktor/src/main/kotlin/dev/webauthn/samples/backend/CommunityConformancePayloads.kt
@@ -1,0 +1,88 @@
+package dev.webauthn.samples.backend
+
+import dev.webauthn.model.Origin
+import dev.webauthn.model.ResidentKeyRequirement
+import dev.webauthn.model.RpId
+import dev.webauthn.model.UserHandle
+import dev.webauthn.model.UserVerificationRequirement
+import dev.webauthn.server.RegistrationStartRequest
+import java.security.MessageDigest
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+internal fun JsonObject.toRegistrationStartRequest(
+    username: String,
+    config: CommunityConformanceConfig,
+): RegistrationStartRequest {
+    val authenticatorSelection = this["authenticatorSelection"]?.jsonObject
+    return RegistrationStartRequest(
+        rpId = RpId.parseOrThrow(config.rpId),
+        rpName = config.rpName,
+        origin = Origin.parseOrThrow(config.origin),
+        userName = username,
+        userDisplayName = stringValue("displayName") ?: stringValue("userDisplayName") ?: username,
+        userHandle = deterministicUserHandle(username),
+        residentKey = authenticatorSelection.toResidentKeyRequirement(),
+        userVerification = authenticatorSelection.toUserVerificationRequirement(),
+    )
+}
+
+internal fun JsonObject.communityOptionsResponse(
+    optionsJson: JsonObject,
+): JsonObject {
+    val payload = this
+    return buildJsonObject {
+        put("status", "ok")
+        put("errorMessage", "")
+        optionsJson.forEach { (key, value) -> put(key, value) }
+        payload.stringValue("attestation")?.let { put("attestation", it) }
+        payload["authenticatorSelection"]?.let { put("authenticatorSelection", it) }
+    }
+}
+
+internal fun JsonObject.stringValue(key: String): String? =
+    this[key]?.jsonPrimitive?.contentOrNull
+
+private fun JsonObject?.toResidentKeyRequirement(): ResidentKeyRequirement {
+    val residentKey = this?.stringValue("residentKey")?.toResidentKeyRequirement()
+    if (residentKey != null) {
+        return residentKey
+    }
+    return when (this?.get("requireResidentKey")?.jsonPrimitive?.booleanOrNull) {
+        true -> ResidentKeyRequirement.REQUIRED
+        false,
+        null,
+        -> ResidentKeyRequirement.PREFERRED
+    }
+}
+
+private fun JsonObject?.toUserVerificationRequirement(): UserVerificationRequirement =
+    this?.stringValue("userVerification")?.toUserVerificationRequirement()
+        ?: UserVerificationRequirement.PREFERRED
+
+private fun String.toResidentKeyRequirement(): ResidentKeyRequirement? =
+    when (lowercase()) {
+        "required" -> ResidentKeyRequirement.REQUIRED
+        "preferred" -> ResidentKeyRequirement.PREFERRED
+        "discouraged" -> ResidentKeyRequirement.DISCOURAGED
+        else -> null
+    }
+
+private fun String.toUserVerificationRequirement(): UserVerificationRequirement? =
+    when (lowercase()) {
+        "required" -> UserVerificationRequirement.REQUIRED
+        "preferred" -> UserVerificationRequirement.PREFERRED
+        "discouraged" -> UserVerificationRequirement.DISCOURAGED
+        else -> null
+    }
+
+private fun deterministicUserHandle(username: String): UserHandle {
+    val digest = MessageDigest.getInstance("SHA-256")
+        .digest(username.encodeToByteArray())
+    return UserHandle.fromBytes(digest)
+}

--- a/sample/backend-ktor/src/main/kotlin/dev/webauthn/samples/backend/CommunityConformanceRoutes.kt
+++ b/sample/backend-ktor/src/main/kotlin/dev/webauthn/samples/backend/CommunityConformanceRoutes.kt
@@ -1,0 +1,105 @@
+package dev.webauthn.samples.backend
+
+import dev.webauthn.model.RegistrationResponse
+import dev.webauthn.model.ValidationResult
+import dev.webauthn.serialization.PublicKeyCredentialCreationOptionsDto
+import dev.webauthn.serialization.WebAuthnDtoMapper
+import dev.webauthn.server.RegistrationFinishRequest
+import dev.webauthn.server.RegistrationService
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
+
+public data class CommunityConformanceConfig(
+    val rpId: String,
+    val rpName: String,
+    val origin: String,
+)
+
+public fun Application.installCommunityConformanceRoutes(
+    registrationService: RegistrationService,
+    config: CommunityConformanceConfig,
+) {
+    routing {
+        post("/attestation/options") {
+            call.handleAttestationOptions(registrationService, config)
+        }
+
+        post("/attestation/result") {
+            call.handleAttestationResult(registrationService)
+        }
+    }
+}
+
+private suspend fun ApplicationCall.handleAttestationOptions(
+    registrationService: RegistrationService,
+    config: CommunityConformanceConfig,
+) {
+    val payload = receive<JsonObject>()
+    val username = payload.stringValue("username")
+        ?: payload.stringValue("userName")
+        ?: return respondConformanceError(HttpStatusCode.BadRequest, "Missing username")
+    val request = payload.toRegistrationStartRequest(username, config)
+    val options = registrationService.start(request)
+    val optionsJson = conformanceJson.encodeToJsonElement(
+        serializer = PublicKeyCredentialCreationOptionsDto.serializer(),
+        value = WebAuthnDtoMapper.fromModel(options),
+    ).jsonObject
+
+    respond(HttpStatusCode.OK, payload.communityOptionsResponse(optionsJson))
+}
+
+private suspend fun ApplicationCall.handleAttestationResult(
+    registrationService: RegistrationService,
+) {
+    val payload = receive<JsonObject>()
+    val response = payload.parseRawRegistrationResponse()
+        ?: return respondConformanceError(HttpStatusCode.BadRequest, "Invalid registration response")
+
+    when (
+        val result = registrationService.finish(
+            RegistrationFinishRequest(response = response),
+        )
+    ) {
+        is ValidationResult.Valid -> respondConformanceRegistrationSuccess(result)
+        is ValidationResult.Invalid -> respondConformanceError(
+            HttpStatusCode.BadRequest,
+            result.errors.joinToString("; ") { "${it.field}: ${it.message}" },
+        )
+    }
+}
+
+private suspend fun ApplicationCall.respondConformanceRegistrationSuccess(
+    result: ValidationResult.Valid<RegistrationResponse>,
+) {
+    respond(
+        HttpStatusCode.OK,
+        mapOf(
+            "status" to "ok",
+            "errorMessage" to "",
+            "credentialId" to result.value.credentialId.value.encoded(),
+        ),
+    )
+}
+
+private suspend fun ApplicationCall.respondConformanceError(
+    status: HttpStatusCode,
+    message: String,
+) {
+    respond(
+        status,
+        mapOf(
+            "status" to "failed",
+            "errorMessage" to message,
+            "errors" to [message],
+        ),
+    )
+}

--- a/sample/backend-ktor/src/main/kotlin/dev/webauthn/samples/backend/Main.kt
+++ b/sample/backend-ktor/src/main/kotlin/dev/webauthn/samples/backend/Main.kt
@@ -85,6 +85,12 @@ public fun Application.installSampleBackend(
         }
     }
     installWebAuthnRoutes(registrationService, authenticationService)
+    if (config.communityConformanceEnabled) {
+        installCommunityConformanceRoutes(
+            registrationService = registrationService,
+            config = config.communityConformanceConfig(),
+        )
+    }
     routing {
         get("/health") {
             call.respond(HttpStatusPayload(status = "ok"))
@@ -137,6 +143,12 @@ public fun Application.installSampleBackend(
                     appendLine("PORT=${config.port}")
                     appendLine("ANDROID_PACKAGE_NAME=${config.androidPackageName}")
                     appendLine("IOS_APP_ID=${config.iosAppId}")
+                    appendLine("WEBAUTHN_CONFORMANCE_ENABLED=${config.communityConformanceEnabled}")
+                    if (config.communityConformanceEnabled) {
+                        appendLine("WEBAUTHN_CONFORMANCE_RP_ID=${config.conformanceRpId}")
+                        appendLine("WEBAUTHN_CONFORMANCE_RP_NAME=${config.conformanceRpName}")
+                        appendLine("WEBAUTHN_CONFORMANCE_ORIGIN=${config.conformanceOrigin}")
+                    }
                     appendLine("AttestationPolicy=${config.attestationPolicy}")
                     config.iosAppIdWarning?.let { warning ->
                         appendLine("WARNING=$warning")
@@ -147,6 +159,10 @@ public fun Application.installSampleBackend(
                     appendLine("POST /webauthn/registration/finish")
                     appendLine("POST /webauthn/authentication/start")
                     appendLine("POST /webauthn/authentication/finish")
+                    if (config.communityConformanceEnabled) {
+                        appendLine("POST /attestation/options")
+                        appendLine("POST /attestation/result")
+                    }
                     appendLine("GET  /health")
                     appendLine("GET  /.well-known/assetlinks.json")
                     appendLine("GET  /.well-known/apple-app-site-association")
@@ -166,7 +182,18 @@ public data class SampleBackendConfig(
     val iosAppId: String = DEFAULT_IOS_APP_ID,
     val iosAppIdWarning: String? = null,
     val attestationPolicy: AttestationPolicy = AttestationPolicy.Strict,
+    val communityConformanceEnabled: Boolean = false,
+    val conformanceRpId: String = "localhost",
+    val conformanceRpName: String = "WebAuthn Kotlin registration canary",
+    val conformanceOrigin: String = "https://localhost:$DEFAULT_PORT",
 ) {
+    public fun communityConformanceConfig(): CommunityConformanceConfig =
+        CommunityConformanceConfig(
+            rpId = conformanceRpId,
+            rpName = conformanceRpName,
+            origin = conformanceOrigin,
+        )
+
     public companion object {
         public fun fromEnvironment(
             environment: Map<String, String> = System.getenv()
@@ -189,6 +216,13 @@ public data class SampleBackendConfig(
                 iosAppId = configuredIosAppId.appId,
                 iosAppIdWarning = configuredIosAppId.warning,
                 attestationPolicy = attestationPolicy,
+                communityConformanceEnabled = environment["WEBAUTHN_CONFORMANCE_ENABLED"]
+                    ?.equals("true", ignoreCase = true) == true,
+                conformanceRpId = environment["WEBAUTHN_CONFORMANCE_RP_ID"].orIfBlank("localhost"),
+                conformanceRpName = environment["WEBAUTHN_CONFORMANCE_RP_NAME"]
+                    .orIfBlank("WebAuthn Kotlin registration canary"),
+                conformanceOrigin = environment["WEBAUTHN_CONFORMANCE_ORIGIN"]
+                    .orIfBlank("https://localhost:$configuredPort"),
             )
         }
 

--- a/sample/backend-ktor/src/test/kotlin/dev/webauthn/samples/backend/CommunityConformanceE2eTest.kt
+++ b/sample/backend-ktor/src/test/kotlin/dev/webauthn/samples/backend/CommunityConformanceE2eTest.kt
@@ -1,0 +1,348 @@
+package dev.webauthn.samples.backend
+
+import dev.webauthn.client.DefaultJsonPasskeyClient
+import dev.webauthn.client.DefaultPasskeyClient
+import dev.webauthn.client.CeremonyResult
+import dev.webauthn.client.PasskeyFlow
+import dev.webauthn.client.PasskeyCapabilities
+import dev.webauthn.client.PasskeyClientError
+import dev.webauthn.client.PasskeyPlatformBridge
+import dev.webauthn.client.PasskeyResult
+import dev.webauthn.model.Base64UrlBytes
+import dev.webauthn.model.PublicKeyCredentialCreationOptions
+import dev.webauthn.model.PublicKeyCredentialRequestOptions
+import dev.webauthn.model.RawAuthenticationResponse
+import dev.webauthn.model.RawRegistrationResponse
+import dev.webauthn.model.ValidationResult
+import dev.webauthn.network.KtorPasskeyRoutes
+import dev.webauthn.network.kotlinx.DefaultPasskeyFinishResult
+import dev.webauthn.network.kotlinx.KotlinxKtorPasskeyBackend
+import dev.webauthn.network.kotlinx.RegistrationStartPayload
+import dev.webauthn.serialization.KotlinxWebAuthnJsonCodec
+import dev.webauthn.serialization.PublicKeyCredentialCreationOptionsDto
+import dev.webauthn.serialization.RegistrationResponseDto
+import dev.webauthn.serialization.RegistrationResponsePayloadDto
+import dev.webauthn.serialization.WebAuthnDtoMapper
+import dev.webauthn.server.AttestationPolicy
+import dev.webauthn.server.AuthenticationService
+import dev.webauthn.server.InMemoryChallengeStore
+import dev.webauthn.server.InMemoryCredentialStore
+import dev.webauthn.server.InMemoryUserAccountStore
+import dev.webauthn.server.RegistrationService
+import dev.webauthn.server.crypto.JvmRpIdHasher
+import dev.webauthn.server.crypto.JvmSignatureVerifier
+import dev.webauthn.server.crypto.StrictAttestationVerifier
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class CommunityConformanceE2eTest {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = false
+    }
+
+    @Test
+    fun attestationOptionsUseAuthoritativeServerConfiguration() = testApplication {
+        val services = backendServices()
+        application {
+            installSampleBackend(
+                registrationService = services.registrationService,
+                authenticationService = services.authenticationService,
+                config = sampleConfig(),
+            )
+        }
+
+        val request = communityOptionsRequest(
+            username = "2cKNGn1rOXC5_C0yR08W",
+            displayName = "Lakeesha Hemstreet",
+            attestation = "direct",
+        )
+        val response = client.post("/attestation/options") {
+            contentType(ContentType.Application.Json)
+            setBody(request)
+        }
+        val responseBody = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("ok", responseBody.getValue("status").jsonPrimitive.content)
+        assertEquals("", responseBody.getValue("errorMessage").jsonPrimitive.content)
+        assertEquals("2cKNGn1rOXC5_C0yR08W", responseBody.getValue("user").jsonObject.getValue("name").jsonPrimitive.content)
+        assertEquals("Lakeesha Hemstreet", responseBody.getValue("user").jsonObject.getValue("displayName").jsonPrimitive.content)
+        assertTrue(responseBody.getValue("user").jsonObject.getValue("id").jsonPrimitive.content.matches(BASE64_URL_REGEX))
+        assertEquals(FIXTURE_RP_ID, responseBody.getValue("rp").jsonObject.getValue("id").jsonPrimitive.content)
+        assertEquals(FIXTURE_RP_NAME, responseBody.getValue("rp").jsonObject.getValue("name").jsonPrimitive.content)
+        assertTrue(responseBody.getValue("challenge").jsonPrimitive.content.matches(BASE64_URL_REGEX))
+        assertTrue(responseBody.getValue("pubKeyCredParams").jsonArray.isNotEmpty())
+        assertEquals("direct", responseBody.getValue("attestation").jsonPrimitive.content)
+        assertEquals(
+            false.toString(),
+            responseBody.getValue("authenticatorSelection").jsonObject
+                .getValue("requireResidentKey")
+                .jsonPrimitive
+                .content,
+        )
+        assertEquals(
+            "preferred",
+            responseBody.getValue("authenticatorSelection").jsonObject
+                .getValue("userVerification")
+                .jsonPrimitive
+                .content,
+        )
+        assertFalse("extensions" in responseBody)
+
+        val secondResponse = client.post("/attestation/options") {
+            contentType(ContentType.Application.Json)
+            setBody(request)
+        }
+        val secondBody = Json.parseToJsonElement(secondResponse.bodyAsText()).jsonObject
+        assertNotEquals(
+            responseBody.getValue("challenge").jsonPrimitive.content,
+            secondBody.getValue("challenge").jsonPrimitive.content,
+        )
+    }
+
+    @Test
+    fun directRegistrationE2eUsesSharedClientAndJsonFacade() = testApplication {
+        val services = backendServices()
+        application {
+            installSampleBackend(
+                registrationService = services.registrationService,
+                authenticationService = services.authenticationService,
+                config = sampleConfig(),
+            )
+        }
+        val httpClient = createClient {
+            install(ContentNegotiation) {
+                json(json)
+            }
+        }
+        val optionsResponse = httpClient.post("/attestation/options") {
+            contentType(ContentType.Application.Json)
+            setBody(
+                communityOptionsRequest(
+                    username = "arthur",
+                    displayName = "Arthur Dent",
+                    attestation = "none",
+                    useLegacyResidentKey = false,
+                ),
+            )
+        }
+        val optionsJson = optionsResponse.bodyAsText()
+        val jsonClient = DefaultJsonPasskeyClient(
+            passkeyClient = DefaultPasskeyClient(FixtureRegistrationBridge(FIXTURE_ORIGIN)),
+            codec = KotlinxWebAuthnJsonCodec(json),
+        )
+        val credentialJson = when (val result = jsonClient.createCredentialJson(optionsJson)) {
+            is PasskeyResult.Success -> result.value
+            is PasskeyResult.Failure -> error("Client registration failed: ${result.error.message}")
+        }
+
+        val credentialPayload = Json.parseToJsonElement(credentialJson).jsonObject
+        val idOnlyCredentialPayload = buildJsonObject {
+            put("id", credentialPayload.getValue("id"))
+            put("type", credentialPayload.getValue("type"))
+            put("response", credentialPayload.getValue("response"))
+        }
+        assertEquals(setOf("id", "type", "response"), idOnlyCredentialPayload.keys)
+
+        val finishResponse = httpClient.post("/attestation/result") {
+            contentType(ContentType.Application.Json)
+            setBody(idOnlyCredentialPayload.toString())
+        }
+        val finishBody = Json.parseToJsonElement(finishResponse.bodyAsText()).jsonObject
+
+        assertEquals(HttpStatusCode.OK, finishResponse.status)
+        assertEquals("ok", finishBody.getValue("status").jsonPrimitive.content)
+        assertEquals(FIXTURE_CREDENTIAL_ID, finishBody.getValue("credentialId").jsonPrimitive.content)
+    }
+
+    @Test
+    fun passkeyFlowCanRunRegistrationThroughConformanceRouteOverrides() = testApplication {
+        val services = backendServices()
+        application {
+            installSampleBackend(
+                registrationService = services.registrationService,
+                authenticationService = services.authenticationService,
+                config = sampleConfig(),
+            )
+        }
+        val httpClient = createClient {
+            install(ContentNegotiation) {
+                json(json)
+            }
+        }
+        val backend = KotlinxKtorPasskeyBackend(
+            httpClient = httpClient,
+            endpointBase = "",
+            routes = KtorPasskeyRoutes(
+                registerOptionsPath = "/attestation/options",
+                registerFinishPath = "/attestation/result",
+            ),
+        )
+        val startPayload = RegistrationStartPayload(
+            rpId = FIXTURE_RP_ID,
+            rpName = FIXTURE_RP_ID,
+            origin = FIXTURE_ORIGIN,
+            userName = "ford",
+            userDisplayName = "Ford Prefect",
+            userHandle = Base64UrlBytes.fromBytes("ford".encodeToByteArray()).encoded(),
+        )
+        val flow = PasskeyFlow(
+            DefaultPasskeyClient(FixtureRegistrationBridge(FIXTURE_ORIGIN)),
+        )
+        val result = flow.register(startPayload, backend.registrationBackend())
+
+        assertEquals(
+            CeremonyResult.Success(DefaultPasskeyFinishResult.Verified),
+            result,
+        )
+    }
+
+    private fun backendServices(): BackendServices {
+        val challengeStore = InMemoryChallengeStore()
+        val credentialStore = InMemoryCredentialStore()
+        val userStore = InMemoryUserAccountStore()
+        return BackendServices(
+            registrationService = RegistrationService(
+                challengeStore = challengeStore,
+                credentialStore = credentialStore,
+                userAccountStore = userStore,
+                attestationVerifier = StrictAttestationVerifier(),
+                rpIdHasher = JvmRpIdHasher(),
+                clientDataDecoder = KotlinxWebAuthnJsonCodec(json),
+                attestationPolicy = AttestationPolicy.None,
+            ),
+            authenticationService = AuthenticationService(
+                challengeStore = challengeStore,
+                credentialStore = credentialStore,
+                userAccountStore = userStore,
+                signatureVerifier = JvmSignatureVerifier(),
+                rpIdHasher = JvmRpIdHasher(),
+                clientDataDecoder = KotlinxWebAuthnJsonCodec(json),
+            ),
+        )
+    }
+
+    private fun sampleConfig(): SampleBackendConfig =
+        SampleBackendConfig(
+            attestationPolicy = AttestationPolicy.None,
+            communityConformanceEnabled = true,
+            conformanceRpId = FIXTURE_RP_ID,
+            conformanceRpName = FIXTURE_RP_NAME,
+            conformanceOrigin = FIXTURE_ORIGIN,
+        )
+
+    private fun communityOptionsRequest(
+        username: String,
+        displayName: String,
+        attestation: String,
+        useLegacyResidentKey: Boolean = true,
+    ): String =
+        buildJsonObject {
+            put("username", username)
+            put("displayName", displayName)
+            put("attestation", attestation)
+            put("rpId", "client-controlled.invalid")
+            put("rpName", "Client-controlled RP")
+            put("origin", "https://client-controlled.invalid")
+            put(
+                "authenticatorSelection",
+                buildJsonObject {
+                    if (useLegacyResidentKey) {
+                        put("requireResidentKey", false)
+                    } else {
+                        put("residentKey", "preferred")
+                    }
+                    put("userVerification", "preferred")
+                },
+            )
+            put(
+                "extensions",
+                buildJsonObject {
+                    put("example.extension", true)
+                },
+            )
+        }.toString()
+
+    private inner class FixtureRegistrationBridge(
+        private val origin: String,
+    ) : PasskeyPlatformBridge {
+        override suspend fun createCredential(options: PublicKeyCredentialCreationOptions): RawRegistrationResponse {
+            val dto = RegistrationResponseDto(
+                id = FIXTURE_CREDENTIAL_ID,
+                rawId = FIXTURE_CREDENTIAL_ID,
+                response = RegistrationResponsePayloadDto(
+                    clientDataJson = clientDataJson(
+                        type = "webauthn.create",
+                        challenge = options.challenge.value.encoded(),
+                        origin = origin,
+                    ),
+                    attestationObject = FIXTURE_ATTESTATION_OBJECT,
+                ),
+            )
+            return when (val result = WebAuthnDtoMapper.toRawModel(dto)) {
+                is ValidationResult.Valid -> result.value
+                is ValidationResult.Invalid -> error("Fixture registration response is invalid: ${result.errors}")
+            }
+        }
+
+        override suspend fun getAssertion(options: PublicKeyCredentialRequestOptions): RawAuthenticationResponse {
+            error("Assertion generation needs a signing software authenticator and is intentionally outside this first CI slice.")
+        }
+
+        override fun mapPlatformError(throwable: Throwable): PasskeyClientError =
+            PasskeyClientError.Platform(throwable.message ?: "fixture bridge failure")
+
+        override suspend fun capabilities(): PasskeyCapabilities =
+            PasskeyCapabilities()
+
+        private fun clientDataJson(
+            type: String,
+            challenge: String,
+            origin: String,
+        ): String {
+            val rawJson = json.encodeToString(
+                buildJsonObject {
+                    put("type", type)
+                    put("challenge", challenge)
+                    put("origin", origin)
+                },
+            )
+            return Base64UrlBytes.fromBytes(rawJson.encodeToByteArray()).encoded()
+        }
+    }
+
+    private companion object {
+        private val BASE64_URL_REGEX = Regex("^[a-zA-Z0-9_-]+$")
+        private const val FIXTURE_RP_ID = "localhost"
+        private const val FIXTURE_RP_NAME = "WebAuthn Kotlin registration canary"
+        private const val FIXTURE_ORIGIN = "https://localhost:8080"
+        private const val FIXTURE_CREDENTIAL_ID = "adnJdzQQOzHT8aobzfRCfA"
+        private const val FIXTURE_ATTESTATION_OBJECT =
+            "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YViUSZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2NdAAAAAOqbjWZNAR0hPOS2tIy1ddQAEGnZyXc0EDsx0_GqG830QnylAQIDJiABIVggd-XJL5odWHADN7Ayg5vk1LfCsAGqC9gpXHMtgtehFjoiWCAnkr58JQNicaTRIf7zALTm0G5Jh1BSTjlfi0HE05IyDA"
+    }
+}
+
+private data class BackendServices(
+    val registrationService: RegistrationService,
+    val authenticationService: AuthenticationService,
+)

--- a/sample/backend-ktor/src/test/kotlin/dev/webauthn/samples/backend/SampleBackendRoutesTest.kt
+++ b/sample/backend-ktor/src/test/kotlin/dev/webauthn/samples/backend/SampleBackendRoutesTest.kt
@@ -10,7 +10,9 @@ import dev.webauthn.server.crypto.JvmRpIdHasher
 import dev.webauthn.server.crypto.JvmSignatureVerifier
 import dev.webauthn.server.crypto.StrictAttestationVerifier
 import io.ktor.client.request.get
+import io.ktor.client.request.post
 import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
 import io.ktor.server.testing.testApplication
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
@@ -81,6 +83,8 @@ class SampleBackendRoutesTest {
         assertTrue(cliBrowserPage.contains("Passkey CLI Browser Handoff"))
         assertTrue(cliBrowserPage.contains("navigator.credentials.create"))
         assertTrue(cliBrowserPage.contains("navigator.credentials.get"))
+
+        assertEquals(HttpStatusCode.NotFound, client.post("/attestation/options").status)
     }
 
     @Test
@@ -92,6 +96,7 @@ class SampleBackendRoutesTest {
         )
         assertEquals(9090, defaultConfig.port)
         assertEquals(AttestationPolicy.Strict, defaultConfig.attestationPolicy)
+        assertEquals(false, defaultConfig.communityConformanceEnabled)
         assertEquals("TEAMID.com.example.app", defaultConfig.iosAppId)
         assertTrue(defaultConfig.iosAppIdWarning?.contains("placeholder") == true)
 
@@ -108,6 +113,19 @@ class SampleBackendRoutesTest {
             ),
         )
         assertEquals(AttestationPolicy.None, noneConfig.attestationPolicy)
+
+        val conformanceConfig = SampleBackendConfig.fromEnvironment(
+            mapOf(
+                "WEBAUTHN_CONFORMANCE_ENABLED" to "true",
+                "WEBAUTHN_CONFORMANCE_RP_ID" to "example.test",
+                "WEBAUTHN_CONFORMANCE_RP_NAME" to "Example Test RP",
+                "WEBAUTHN_CONFORMANCE_ORIGIN" to "https://example.test",
+            ),
+        )
+        assertEquals(true, conformanceConfig.communityConformanceEnabled)
+        assertEquals("example.test", conformanceConfig.conformanceRpId)
+        assertEquals("Example Test RP", conformanceConfig.conformanceRpName)
+        assertEquals("https://example.test", conformanceConfig.conformanceOrigin)
 
         val unknownConfig = SampleBackendConfig.fromEnvironment(
             mapOf(


### PR DESCRIPTION
## Summary

- Add opt-in sample-backend adapters for the FIDO server testing API registration routes, `/attestation/options` and `/attestation/result`.
- Add a dedicated `communityConformanceE2eTest` task and blocking CI canary for options generation and registration finish.
- Exercise the refactored client stack through `DefaultPasskeyClient`, the explicit Kotlinx JSON codec, `PasskeyFlow`, and `KotlinxKtorPasskeyBackend` route overrides.
- Accept the testing API's ID-only registration result shape by deriving a missing `rawId` from `id` at this adapter boundary.

## Security and deployment boundary

The compatibility routes are disabled by default and require `WEBAUTHN_CONFORMANCE_ENABLED=true`. RP ID, RP name, and expected origin come only from server configuration; caller-supplied values are ignored. Unsupported extension input is not reflected into creation options.

Registration finish still passes only `RawRegistrationResponse` into server-core. Challenge, origin, and ceremony type are derived from signed `clientDataJSON`.

## Scope and claims

This is a registration-only interoperability canary for endpoint shape, raw/JSON mapping, challenge handling, and server verification. It is not official FIDO conformance, certification readiness, exhaustive vector coverage, assertion coverage, browser virtual-authenticator coverage, or physical Android/iOS prompt automation.

## Validation

- `./gradlew :sample:backend-ktor:communityConformanceE2eTest :sample:backend-ktor:test --stacktrace`
- `./gradlew docsUpdate --stacktrace`
- `tools/agent/quality-gate.sh --mode strict --scope changed --block false`

Rebuilt on the final refactored `main` after #249-#256 and the Signum dependency updates landed.
