### PR TITLE
ci: add configurable PR change profile decorator

### DIFF
--- a/.github/pr-change-profile.config.json
+++ b/.github/pr-change-profile.config.json
@@ -1,0 +1,69 @@
+{
+  "publishedAreas": ["core", "client", "server"],
+  "testVerificationPrefixes": [
+    "documentation/consumer-smoke/"
+  ],
+  "toolingPrefixes": [
+    ".github/",
+    "build-logic/",
+    "tools/",
+    ".githooks/",
+    ".gemini/",
+    ".kiro/",
+    "config/",
+    "documentation/tooling/"
+  ],
+  "documentationPrefixes": [
+    "docs/",
+    "spec-notes/"
+  ],
+  "documentationExamplePrefixes": [
+    "documentation/examples/"
+  ],
+  "samplePrefixes": [
+    "sample/"
+  ],
+  "publishingPrefixes": [
+    "platform/",
+    "gradle/dependency-locks/"
+  ],
+  "publishingFiles": [
+    "gradle/libs.versions.toml",
+    "gradle/verification-metadata.xml"
+  ],
+  "referencePrefixes": [
+    "spec-cache/"
+  ],
+  "generatedFiles": [
+    "documentation/example-inventory.md"
+  ],
+  "rootDocumentationFiles": [
+    "README.md",
+    "CONTRIBUTING.md",
+    "SECURITY.md",
+    "AGENTS.md",
+    "CLAUDE.md",
+    "CODE_OF_CONDUCT.md",
+    "CHANGELOG.md",
+    "LICENSE",
+    "LICENSE.md"
+  ],
+  "sourceExtensions": [
+    ".kt",
+    ".kts",
+    ".java",
+    ".swift",
+    ".js",
+    ".mjs",
+    ".cjs",
+    ".ts",
+    ".tsx",
+    ".c",
+    ".cc",
+    ".cpp",
+    ".h",
+    ".hpp",
+    ".sql",
+    ".sq"
+  ]
+}

--- a/.github/scripts/pr-change-profile.cjs
+++ b/.github/scripts/pr-change-profile.cjs
@@ -1,0 +1,442 @@
+const MARKER = '<!-- webauthn-pr-change-profile:v1 -->'
+
+const CATEGORY_META = {
+  published: { label: '📦 Published library source' },
+  test: { label: '🧪 Tests / verification' },
+  sample: { label: '🧭 Samples / demos' },
+  docs_examples: { label: '📖 Documentation examples' },
+  docs: { label: '📚 Documentation / specifications' },
+  tooling: { label: '🔧 Build / CI / repo tooling' },
+  publishing: { label: '📦 Publishing / dependency metadata' },
+  api: { label: '📐 Public API baselines' },
+  generated_reference: { label: '⚙️ Generated / reference material' },
+  unclassified: { label: '⚠️ Unclassified source' },
+  other: { label: '◻️ Other' },
+}
+
+const CATEGORY_ORDER = [
+  'published',
+  'test',
+  'sample',
+  'docs_examples',
+  'docs',
+  'tooling',
+  'publishing',
+  'api',
+  'generated_reference',
+  'unclassified',
+  'other',
+]
+
+function startsWithAny(value, prefixes = []) {
+  return prefixes.some(prefix => value.startsWith(prefix))
+}
+
+function isTestSource(path) {
+  return /\/src\/(?:testFixtures|test|[^/]*Test)(?:\/|$)/.test(path)
+}
+
+function isApiBaseline(path) {
+  return /(?:^|\/)api\/.*(?:\.api|\.klib\.api)$/.test(path)
+}
+
+function isBuildOrRepoMetadata(path) {
+  if ([
+    'build.gradle.kts',
+    'settings.gradle.kts',
+    'gradle.properties',
+    'gradlew',
+    'gradlew.bat',
+  ].includes(path)) {
+    return true
+  }
+
+  return /(?:^|\/)(?:build\.gradle\.kts|settings\.gradle\.kts|gradle\.properties)$/.test(path)
+    || /(?:^|\/)gradle\.lockfile$/.test(path)
+}
+
+function isDocumentationPath(path, config) {
+  if ((config.rootDocumentationFiles || []).includes(path)) {
+    return true
+  }
+
+  if (startsWithAny(path, config.documentationPrefixes)) {
+    return true
+  }
+
+  const basename = path.split('/').at(-1)
+  return basename === 'README.md'
+    || basename === 'CONTRIBUTING.md'
+    || basename === 'SECURITY.md'
+    || basename === 'CHANGELOG.md'
+    || basename === 'LICENSE'
+    || basename === 'LICENSE.md'
+}
+
+function isPublishedSource(path, config) {
+  const [area] = path.split('/')
+  if (!(config.publishedAreas || []).includes(area)) {
+    return false
+  }
+  return /\/src\/(?:main|[^/]*Main)(?:\/|$)/.test(path)
+}
+
+function isSourceLike(path, config) {
+  return (config.sourceExtensions || []).some(extension => path.endsWith(extension))
+}
+
+function classifyPath(path, config) {
+  if (isTestSource(path)) return 'test'
+  if (startsWithAny(path, config.testVerificationPrefixes)) return 'test'
+  if ((config.generatedFiles || []).includes(path)) return 'generated_reference'
+  if (isApiBaseline(path)) return 'api'
+  if (startsWithAny(path, config.toolingPrefixes)) return 'tooling'
+  if (isDocumentationPath(path, config)) return 'docs'
+  if (startsWithAny(path, config.publishingPrefixes) || (config.publishingFiles || []).includes(path)) return 'publishing'
+  if (isBuildOrRepoMetadata(path)) return 'tooling'
+  if (startsWithAny(path, config.documentationExamplePrefixes)) return 'docs_examples'
+  if (startsWithAny(path, config.samplePrefixes)) return 'sample'
+  if (isPublishedSource(path, config)) return 'published'
+  if (startsWithAny(path, config.referencePrefixes)) return 'generated_reference'
+  if (path.startsWith('documentation/')) return 'docs'
+  return isSourceLike(path, config) ? 'unclassified' : 'other'
+}
+
+function extractModule(path) {
+  const parts = path.split('/')
+  if (['core', 'client', 'server', 'sample', 'platform', 'documentation'].includes(parts[0]) && parts[1]) {
+    return {
+      area: parts[0],
+      module: parts[1],
+      key: `${parts[0]}/${parts[1]}`,
+    }
+  }
+
+  if (['build-logic', 'tools', 'gradle', 'config', 'spec-cache', 'spec-notes'].includes(parts[0])) {
+    return { area: parts[0], module: parts[0], key: parts[0] }
+  }
+
+  if (parts[0] === '.github') return { area: '.github', module: '.github', key: '.github' }
+  return { area: 'repository', module: 'repository', key: 'repository' }
+}
+
+function extractPublishedPlatform(path) {
+  const match = path.match(/\/src\/([^/]+)\//)
+  if (!match) return null
+  const sourceSet = match[1]
+
+  if (sourceSet === 'commonMain') return 'Common'
+  if (sourceSet === 'main' || sourceSet === 'jvmMain') return 'JVM'
+  if (sourceSet === 'androidMain') return 'Android'
+  if (sourceSet === 'iosMain' || sourceSet === 'appleMain' || sourceSet.startsWith('ios')) return 'iOS / Apple'
+  if (sourceSet === 'jsMain' || sourceSet === 'wasmJsMain') return 'JS / Web'
+  if (sourceSet === 'nativeMain' || /^(?:macos|linux|mingw)/.test(sourceSet)) return 'Native'
+  if (sourceSet.endsWith('Main')) return sourceSet
+  return null
+}
+
+function emptyStats() {
+  return { files: 0, additions: 0, deletions: 0, churn: 0 }
+}
+
+function addFileStats(target, file) {
+  target.files += 1
+  target.additions += file.additions || 0
+  target.deletions += file.deletions || 0
+  target.churn += (file.additions || 0) + (file.deletions || 0)
+}
+
+function aggregateFiles(files, config) {
+  const categories = Object.fromEntries(CATEGORY_ORDER.map(category => [category, emptyStats()]))
+  const modules = new Map()
+  const publishedPlatforms = new Map()
+  const classifiedFiles = []
+
+  for (const file of files) {
+    const category = classifyPath(file.filename, config)
+    const module = extractModule(file.filename)
+    const classified = { ...file, category, module }
+    classifiedFiles.push(classified)
+    addFileStats(categories[category], file)
+
+    if (['core', 'client', 'server'].includes(module.area) && ['published', 'test', 'api'].includes(category)) {
+      if (!modules.has(module.key)) {
+        modules.set(module.key, {
+          area: module.area,
+          module: module.module,
+          published: emptyStats(),
+          test: emptyStats(),
+          api: emptyStats(),
+        })
+      }
+      addFileStats(modules.get(module.key)[category], file)
+    }
+
+    if (category === 'published') {
+      const platform = extractPublishedPlatform(file.filename) || 'Other published source'
+      if (!publishedPlatforms.has(platform)) publishedPlatforms.set(platform, emptyStats())
+      addFileStats(publishedPlatforms.get(platform), file)
+    }
+  }
+
+  const totals = emptyStats()
+  for (const category of CATEGORY_ORDER) {
+    totals.files += categories[category].files
+    totals.additions += categories[category].additions
+    totals.deletions += categories[category].deletions
+    totals.churn += categories[category].churn
+  }
+
+  return {
+    categories,
+    totals,
+    modules: [...modules.values()],
+    publishedPlatforms: [...publishedPlatforms.entries()].map(([platform, stats]) => ({ platform, ...stats })),
+    classifiedFiles,
+  }
+}
+
+function formatNumber(number) {
+  return new Intl.NumberFormat('en-US').format(number)
+}
+
+function formatRatio(numerator, denominator) {
+  if (denominator === 0) return 'n/a'
+  return `${(numerator / denominator).toFixed(2)}×`
+}
+
+function formatPercent(part, total) {
+  if (total === 0) return '0.0%'
+  return `${((part / total) * 100).toFixed(1)}%`
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replace(/[\r\n]+/g, ' ')
+}
+
+function inlineCode(value) {
+  return `<code>${escapeHtml(value)}</code>`
+}
+
+function tableText(value) {
+  return escapeHtml(value).replaceAll('|', '&#124;')
+}
+
+function renderCategoryTable(stats) {
+  const rows = [
+    '| Category | Files | Added | Deleted | Churn | Share |',
+    '|---|---:|---:|---:|---:|---:|',
+  ]
+
+  for (const category of CATEGORY_ORDER) {
+    const values = stats.categories[category]
+    if (values.files === 0) continue
+    rows.push(
+      `| ${CATEGORY_META[category].label} | ${formatNumber(values.files)} | +${formatNumber(values.additions)} | -${formatNumber(values.deletions)} | ${formatNumber(values.churn)} | ${formatPercent(values.churn, stats.totals.churn)} |`,
+    )
+  }
+
+  return rows.join('\n')
+}
+
+function renderModuleTable(stats) {
+  const modules = stats.modules
+    .filter(module => module.published.churn + module.test.churn + module.api.churn > 0)
+    .sort((a, b) => {
+      const aChurn = a.published.churn + a.test.churn + a.api.churn
+      const bChurn = b.published.churn + b.test.churn + b.api.churn
+      return bChurn - aChurn || a.module.localeCompare(b.module)
+    })
+
+  if (modules.length === 0) return ''
+
+  const rows = [
+    '<details>',
+    '<summary>Published changes by module</summary>',
+    '',
+    '| Module | Published churn | Test churn | API churn |',
+    '|---|---:|---:|---:|',
+  ]
+
+  for (const module of modules) {
+    rows.push(`| <code>${tableText(module.module)}</code> | ${formatNumber(module.published.churn)} | ${formatNumber(module.test.churn)} | ${formatNumber(module.api.churn)} |`)
+  }
+
+  rows.push('', '</details>')
+  return rows.join('\n')
+}
+
+function renderPlatformTable(stats) {
+  const platforms = [...stats.publishedPlatforms]
+    .filter(platform => platform.churn > 0)
+    .sort((a, b) => b.churn - a.churn || a.platform.localeCompare(b.platform))
+
+  if (platforms.length === 0) return ''
+
+  const rows = [
+    '<details>',
+    '<summary>Published source by platform/source set</summary>',
+    '',
+    '| Platform / source set | Files | Churn |',
+    '|---|---:|---:|',
+  ]
+
+  for (const platform of platforms) {
+    rows.push(`| ${tableText(platform.platform)} | ${formatNumber(platform.files)} | ${formatNumber(platform.churn)} |`)
+  }
+
+  rows.push('', '</details>')
+  return rows.join('\n')
+}
+
+function renderUnclassified(stats) {
+  const files = stats.classifiedFiles.filter(file => file.category === 'unclassified')
+  if (files.length === 0) return ''
+
+  const shown = files.slice(0, 20)
+  const lines = [
+    '> [!WARNING]',
+    `> ${files.length} source-like file${files.length === 1 ? '' : 's'} did not match a known repository layout. Review the classifier before relying on the category totals.`,
+    '',
+    '<details>',
+    '<summary>Unclassified source files</summary>',
+    '',
+    ...shown.map(file => `- ${inlineCode(file.filename)}`),
+  ]
+
+  if (files.length > shown.length) lines.push(`- …and ${files.length - shown.length} more`)
+  lines.push('', '</details>')
+  return lines.join('\n')
+}
+
+function renderComment({ pr, stats, incomplete = false, includeMarker = true }) {
+  const published = stats.categories.published
+  const tests = stats.categories.test
+  const relevantChurn = published.churn + tests.churn
+  const lines = []
+
+  if (includeMarker) lines.push(MARKER, '')
+  lines.push(
+    '## 📊 PR change profile',
+    '',
+    `Compared with ${inlineCode(pr.base.ref)} · head ${inlineCode(pr.head.sha.slice(0, 7))}`,
+    '',
+  )
+
+  if (incomplete) {
+    lines.push(
+      '> [!WARNING]',
+      '> GitHub returned fewer changed files than the PR reports. The statistics below are incomplete.',
+      '',
+    )
+  }
+
+  lines.push(
+    renderCategoryTable(stats),
+    '',
+    '**Published source vs verification**',
+    '',
+    `- Published source churn: **${formatNumber(published.churn)}**`,
+    `- Test / verification churn: **${formatNumber(tests.churn)}**`,
+    `- Tests: **${formatPercent(tests.churn, relevantChurn)}** of published + test churn`,
+    `- Test / published additions: **${formatRatio(tests.additions, published.additions)}**`,
+    '',
+    '> Change volume is descriptive; it is not a test coverage metric.',
+  )
+
+  const moduleTable = renderModuleTable(stats)
+  if (moduleTable) lines.push('', moduleTable)
+
+  const platformTable = renderPlatformTable(stats)
+  if (platformTable) lines.push('', platformTable)
+
+  const unclassified = renderUnclassified(stats)
+  if (unclassified) lines.push('', unclassified)
+
+  lines.push(
+    '',
+    '<details>',
+    '<summary>Classification notes</summary>',
+    '',
+    '- Published source is shipped code under `core/`, `client/`, and `server/` production source sets.',
+    '- Tests include test source sets, test fixtures, and committed external-consumer verification fixtures.',
+    '- Samples, documentation examples, API baselines, build/CI/tooling, publishing metadata, and generated/reference material are tracked separately.',
+    '- Metrics come from GitHub PR file metadata; PR code is not executed to produce this comment.',
+    '',
+    '</details>',
+  )
+
+  return lines.join('\n')
+}
+
+async function upsertComment({ github, owner, repo, prNumber, body }) {
+  const comments = await github.paginate(
+    github.rest.issues.listComments,
+    { owner, repo, issue_number: prNumber, per_page: 100 },
+  )
+
+  const existing = comments.find(comment =>
+    comment.user?.login === 'github-actions[bot]' && comment.body?.includes(MARKER),
+  )
+
+  if (!existing) {
+    await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body })
+    return 'created'
+  }
+
+  if (existing.body === body) return 'unchanged'
+
+  await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body })
+  return 'updated'
+}
+
+async function run({ github, context, core, prNumber, config }) {
+  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+    throw new Error(`Invalid pull request number: ${prNumber}`)
+  }
+
+  const { owner, repo } = context.repo
+  const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber })
+  const files = await github.paginate(
+    github.rest.pulls.listFiles,
+    { owner, repo, pull_number: prNumber, per_page: 100 },
+  )
+
+  const incomplete = pr.changed_files > files.length
+  const stats = aggregateFiles(files, config)
+
+  if (!incomplete) {
+    if (stats.totals.files !== pr.changed_files) {
+      throw new Error(`File-count invariant failed: classified=${stats.totals.files}, PR=${pr.changed_files}`)
+    }
+    if (stats.totals.additions !== pr.additions) {
+      throw new Error(`Addition invariant failed: classified=${stats.totals.additions}, PR=${pr.additions}`)
+    }
+    if (stats.totals.deletions !== pr.deletions) {
+      throw new Error(`Deletion invariant failed: classified=${stats.totals.deletions}, PR=${pr.deletions}`)
+    }
+  }
+
+  const body = renderComment({ pr, stats, incomplete })
+  const result = await upsertComment({ github, owner, repo, prNumber, body })
+
+  core.info(`PR change profile ${result}: ${stats.totals.files} files, ${stats.totals.churn} lines of churn`)
+  await core.summary.addRaw(renderComment({ pr, stats, incomplete, includeMarker: false })).write()
+}
+
+module.exports = {
+  MARKER,
+  CATEGORY_META,
+  CATEGORY_ORDER,
+  classifyPath,
+  extractModule,
+  extractPublishedPlatform,
+  aggregateFiles,
+  renderComment,
+  upsertComment,
+  run,
+}

--- a/.github/scripts/pr-change-profile.test.cjs
+++ b/.github/scripts/pr-change-profile.test.cjs
@@ -1,0 +1,264 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const profile = require('./pr-change-profile.cjs')
+const config = require('../pr-change-profile.config.json')
+
+const cases = [
+  ['core/webauthn-core/src/commonMain/kotlin/dev/webauthn/core/TestFactory.kt', 'published'],
+  ['client/webauthn-client-platform/src/androidMain/kotlin/dev/webauthn/client/AndroidClient.kt', 'published'],
+  ['client/webauthn-client-platform/src/iosMain/kotlin/dev/webauthn/client/IosClient.kt', 'published'],
+  ['client/webauthn-client-flow/src/commonMain/kotlin/dev/webauthn/client/PasskeyFlow.kt', 'published'],
+  ['client/webauthn-client-ktor-kotlinx/src/commonMain/kotlin/dev/webauthn/network/KotlinxCodec.kt', 'published'],
+  ['core/webauthn-json-api/src/commonMain/kotlin/dev/webauthn/json/WebAuthnJsonCodec.kt', 'published'],
+  ['server/webauthn-server-core-jvm/src/main/kotlin/dev/webauthn/server/Server.kt', 'published'],
+  ['core/webauthn-core/src/commonTest/kotlin/dev/webauthn/core/ProductionFactory.kt', 'test'],
+  ['client/webauthn-client-platform/src/androidHostTest/kotlin/dev/webauthn/client/ClientTest.kt', 'test'],
+  ['server/webauthn-server-core-jvm/src/testFixtures/kotlin/dev/webauthn/server/StoreContractTestBase.kt', 'test'],
+  ['documentation/consumer-smoke/client/src/commonMain/kotlin/smoke/client/CommonSmoke.kt', 'test'],
+  ['documentation/examples/src/commonTest/kotlin/dev/webauthn/documentation/examples/DocumentationBehaviorTest.kt', 'test'],
+  ['documentation/examples/src/commonMain/kotlin/dev/webauthn/documentation/examples/ModelExample.kt', 'docs_examples'],
+  ['documentation/examples/build.gradle.kts', 'tooling'],
+  ['documentation/tooling/src/main/kotlin/dev/webauthn/documentation/DocumentationExamples.kt', 'tooling'],
+  ['documentation/tooling/src/test/kotlin/dev/webauthn/documentation/DocumentationVerifierTest.kt', 'test'],
+  ['sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/App.kt', 'sample'],
+  ['sample/compose-passkey/src/commonTest/kotlin/dev/webauthn/samples/AppTest.kt', 'test'],
+  ['sample/backend-ktor/build.gradle.kts', 'tooling'],
+  ['platform/bom/build.gradle.kts', 'publishing'],
+  ['gradle/libs.versions.toml', 'publishing'],
+  ['core/webauthn-core/api/webauthn-core.api', 'api'],
+  ['client/webauthn-client-core/api/webauthn-client-core.klib.api', 'api'],
+  ['documentation/example-inventory.md', 'generated_reference'],
+  ['spec-cache/webauthn-3.html', 'generated_reference'],
+  ['spec-cache/README.md', 'docs'],
+  ['docs/IMPLEMENTATION_STATUS.md', 'docs'],
+  ['server/webauthn-server-ktor/README.md', 'docs'],
+  ['README.md', 'docs'],
+  ['build-logic/src/main/kotlin/webauthn.kotlin.multiplatform.gradle.kts', 'tooling'],
+  ['tools/agent/quality-gate.sh', 'tooling'],
+  ['.github/workflows/ci.yml', 'tooling'],
+  ['.gemini/workflows/fast-pr-check.md', 'tooling'],
+  ['.kiro/steering/10-quality-gates.md', 'tooling'],
+  ['new-area/foo/src/commonMain/kotlin/Foo.kt', 'unclassified'],
+  ['assets/logo.png', 'other'],
+]
+
+for (const [path, expected] of cases) {
+  test(`classifies ${path} as ${expected}`, () => {
+    assert.equal(profile.classifyPath(path, config), expected)
+  })
+}
+
+test('extracts repository modules', () => {
+  assert.deepEqual(profile.extractModule('client/webauthn-client-platform/src/commonMain/kotlin/Foo.kt'), {
+    area: 'client',
+    module: 'webauthn-client-platform',
+    key: 'client/webauthn-client-platform',
+  })
+  assert.deepEqual(profile.extractModule('.github/workflows/ci.yml'), {
+    area: '.github',
+    module: '.github',
+    key: '.github',
+  })
+})
+
+test('groups published source sets into review-oriented platforms', () => {
+  assert.equal(profile.extractPublishedPlatform('core/x/src/commonMain/kotlin/Foo.kt'), 'Common')
+  assert.equal(profile.extractPublishedPlatform('server/x/src/main/kotlin/Foo.kt'), 'JVM')
+  assert.equal(profile.extractPublishedPlatform('client/x/src/androidMain/kotlin/Foo.kt'), 'Android')
+  assert.equal(profile.extractPublishedPlatform('client/x/src/iosMain/kotlin/Foo.kt'), 'iOS / Apple')
+  assert.equal(profile.extractPublishedPlatform('client/x/src/wasmJsMain/kotlin/Foo.kt'), 'JS / Web')
+})
+
+test('aggregates every file exactly once', () => {
+  const files = [
+    { filename: 'core/webauthn-core/src/commonMain/kotlin/Foo.kt', additions: 20, deletions: 5 },
+    { filename: 'core/webauthn-core/src/commonTest/kotlin/FooTest.kt', additions: 30, deletions: 2 },
+    { filename: 'core/webauthn-core/api/webauthn-core.api', additions: 4, deletions: 1 },
+    { filename: 'sample/compose-passkey/src/commonMain/kotlin/App.kt', additions: 10, deletions: 0 },
+    { filename: 'README.md', additions: 5, deletions: 3 },
+  ]
+
+  const stats = profile.aggregateFiles(files, config)
+  assert.deepEqual(stats.totals, { files: 5, additions: 69, deletions: 11, churn: 80 })
+  assert.equal(stats.categories.published.churn, 25)
+  assert.equal(stats.categories.test.churn, 32)
+  assert.equal(stats.categories.api.churn, 5)
+  assert.equal(stats.categories.sample.churn, 10)
+  assert.equal(stats.categories.docs.churn, 8)
+  assert.equal(stats.modules.length, 1)
+  assert.equal(stats.modules[0].module, 'webauthn-core')
+  assert.equal(stats.modules[0].published.churn, 25)
+  assert.equal(stats.modules[0].test.churn, 32)
+  assert.equal(stats.modules[0].api.churn, 5)
+})
+
+test('renders zero-production PRs without invalid ratios', () => {
+  const stats = profile.aggregateFiles([
+    { filename: 'README.md', additions: 10, deletions: 2 },
+  ], config)
+  const body = profile.renderComment({
+    pr: { base: { ref: 'main' }, head: { sha: '1234567890abcdef' } },
+    stats,
+  })
+
+  assert.match(body, /Test \/ published additions: \*\*n\/a\*\*/)
+  assert.doesNotMatch(body, /NaN|Infinity/)
+})
+
+test('surfaces unclassified source paths', () => {
+  const stats = profile.aggregateFiles([
+    { filename: 'experimental/foo/src/commonMain/kotlin/Foo.kt', additions: 3, deletions: 1 },
+  ], config)
+  const body = profile.renderComment({
+    pr: { base: { ref: 'main' }, head: { sha: '1234567890abcdef' } },
+    stats,
+  })
+
+  assert.match(body, /Unclassified source files/)
+  assert.match(body, /experimental\/foo\/src\/commonMain\/kotlin\/Foo\.kt/)
+})
+
+test('escapes untrusted path metadata before rendering it', () => {
+  const stats = profile.aggregateFiles([
+    { filename: 'experimental/<script>|name\n/src/commonMain/kotlin/Foo.kt', additions: 3, deletions: 1 },
+  ], config)
+  const body = profile.renderComment({
+    pr: { base: { ref: 'feature/<unsafe>' }, head: { sha: '1234567890abcdef' } },
+    stats,
+  })
+
+  assert.doesNotMatch(body, /<script>|<unsafe>/)
+  assert.match(body, /&lt;script&gt;\|name/)
+  assert.match(body, /feature\/&lt;unsafe&gt;/)
+})
+
+test('escapes untrusted module names inside Markdown tables', () => {
+  const stats = profile.aggregateFiles([
+    { filename: 'core/<script>|module/src/commonMain/kotlin/Foo.kt', additions: 3, deletions: 1 },
+  ], config)
+  const body = profile.renderComment({
+    pr: { base: { ref: 'main' }, head: { sha: '1234567890abcdef' } },
+    stats,
+  })
+
+  assert.doesNotMatch(body, /<script>|<code>[^\n]*\|module/)
+  assert.match(body, /<code>&lt;script&gt;&#124;module<\/code>/)
+})
+
+test('creates the marker comment when none exists', async () => {
+  const calls = []
+  const github = {
+    rest: {
+      issues: {
+        listComments: Symbol('listComments'),
+        createComment: async args => calls.push(['create', args]),
+        updateComment: async args => calls.push(['update', args]),
+      },
+    },
+    paginate: async () => [],
+  }
+
+  const body = `${profile.MARKER}\nnew`
+  const result = await profile.upsertComment({
+    github,
+    owner: 'szijpeter',
+    repo: 'webauthn-kotlin-multiplatform',
+    prNumber: 123,
+    body,
+  })
+
+  assert.equal(result, 'created')
+  assert.deepEqual(calls, [[
+    'create',
+    {
+      owner: 'szijpeter',
+      repo: 'webauthn-kotlin-multiplatform',
+      issue_number: 123,
+      body,
+    },
+  ]])
+})
+
+test('updates the existing GitHub Actions marker comment', async () => {
+  const calls = []
+  const github = {
+    rest: {
+      issues: {
+        listComments: Symbol('listComments'),
+        createComment: async args => calls.push(['create', args]),
+        updateComment: async args => calls.push(['update', args]),
+      },
+    },
+    paginate: async () => [{
+      id: 42,
+      user: { login: 'github-actions[bot]' },
+      body: `${profile.MARKER}\nold`,
+    }],
+  }
+
+  const result = await profile.upsertComment({
+    github,
+    owner: 'szijpeter',
+    repo: 'webauthn-kotlin-multiplatform',
+    prNumber: 123,
+    body: `${profile.MARKER}\nnew`,
+  })
+
+  assert.equal(result, 'updated')
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0][0], 'update')
+  assert.equal(calls[0][1].comment_id, 42)
+})
+
+test('run publishes an explicit warning when GitHub returns an incomplete file list', async () => {
+  const createdComments = []
+  const infoMessages = []
+  let summaryBody = ''
+  const pulls = {
+    get: async () => ({
+      data: {
+        base: { ref: 'main' },
+        head: { sha: '1234567890abcdef' },
+        changed_files: 2,
+        additions: 99,
+        deletions: 99,
+      },
+    }),
+    listFiles: Symbol('listFiles'),
+  }
+  const issues = {
+    listComments: Symbol('listComments'),
+    createComment: async args => createdComments.push(args),
+    updateComment: async () => assert.fail('did not expect an update'),
+  }
+  const github = {
+    rest: { pulls, issues },
+    paginate: async endpoint => {
+      if (endpoint === pulls.listFiles) {
+        return [{ filename: 'README.md', additions: 5, deletions: 1 }]
+      }
+      if (endpoint === issues.listComments) return []
+      throw new Error('unexpected pagination endpoint')
+    },
+  }
+  const summary = {
+    addRaw: body => {
+      summaryBody = body
+      return summary
+    },
+    write: async () => {},
+  }
+
+  await profile.run({
+    github,
+    context: { repo: { owner: 'szijpeter', repo: 'webauthn-kotlin-multiplatform' } },
+    core: { info: message => infoMessages.push(message), summary },
+    prNumber: 123,
+    config,
+  })
+
+  assert.equal(createdComments.length, 1)
+  assert.match(createdComments[0].body, /statistics below are incomplete/)
+  assert.match(summaryBody, /statistics below are incomplete/)
+  assert.match(infoMessages[0], /1 files, 6 lines of churn/)
+})

--- a/.github/workflows/pr-change-profile-selftest.yml
+++ b/.github/workflows/pr-change-profile-selftest.yml
@@ -1,0 +1,26 @@
+name: PR change profile self-test
+
+on:
+  pull_request:
+    paths:
+      - '.github/pr-change-profile.config.json'
+      - '.github/scripts/pr-change-profile.cjs'
+      - '.github/scripts/pr-change-profile.test.cjs'
+      - '.github/workflows/pr-change-profile.yml'
+      - '.github/workflows/pr-change-profile-selftest.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Test PR change profiler
+        run: node --test .github/scripts/pr-change-profile.test.cjs

--- a/.github/workflows/pr-change-profile.yml
+++ b/.github/workflows/pr-change-profile.yml
@@ -1,0 +1,53 @@
+name: PR change profile
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-change-profile-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  profile:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      # This workflow is privileged so it can update fork PR comments. Keep the
+      # executable profiler pinned to the trusted default branch; PR contents
+      # are API data only and the PR head is never checked out or executed.
+      - name: Checkout trusted profiler
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+          sparse-checkout: .github
+
+      - name: Update PR change profile
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        with:
+          retries: 2
+          script: |
+            const profile = require('./.github/scripts/pr-change-profile.cjs')
+            const config = require('./.github/pr-change-profile.config.json')
+
+            await profile.run({
+              github,
+              context,
+              core,
+              prNumber: Number(process.env.PR_NUMBER),
+              config,
+            })

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,6 +36,7 @@ When reporting, include affected module(s), threat model assumptions, and whethe
 - Java/Kotlin CodeQL scanning is temporarily disabled while the current CodeQL CLI toolchain does not support Kotlin `2.3.10`.
 - Dependency risk is enforced on pull requests via `actions/dependency-review-action`.
 - CI checkout steps disable persisted Git credentials before Gradle executes repository code.
+- The privileged PR change-profile workflow loads executable code and configuration only from the trusted default branch. It never checks out or executes a pull request head; untrusted PR content is consumed only as GitHub API metadata, with `contents: read` and `pull-requests: write` permissions.
 - Renovate manages dependency and GitHub Actions updates.
 - The sample backend defaults to strict attestation verification; use `WEBAUTHN_SAMPLE_ATTESTATION=NONE` only as an explicit local-development override.
 - Maven Central publication is a manual workflow and requires signing plus Central Portal credentials.

--- a/docs/PUBLIC_LAUNCH_CHECKLIST.md
+++ b/docs/PUBLIC_LAUNCH_CHECKLIST.md
@@ -8,6 +8,7 @@ Use this checklist when moving from private to public operation.
 2. CI workflows use least-privilege `permissions`, explicit versioned action references, and
    `persist-credentials: false` on every checkout before repository code executes.
    - `Publish` workflow requires `contents:write` only to create the release tag in `publish-and-release` mode.
+   - Any privileged `pull_request_target` workflow checks out executable code and configuration only from the trusted default branch, never a pull request head, and treats pull request content as API metadata only.
 3. Dependency automation exists and is current: `.github/renovate.json`.
 4. Local/sensitive files are ignored (`.env*`, `local.properties`, build outputs, IDE state).
 5. Required quality and release-preflight gates pass:

--- a/docs/ai/WORKFLOWS.md
+++ b/docs/ai/WORKFLOWS.md
@@ -27,6 +27,7 @@ tools/agent/quality-gate.sh --mode strict --scope changed --block false
 
 4. Let PR CI remain the blocking authority.
 5. CI checkout steps must disable persisted credentials before executing repository code.
+   Privileged `pull_request_target` workflows must load executable code and configuration only from the trusted default branch, must never check out or execute the pull request head, and may consume pull request content only as API metadata with least-privilege permissions.
 6. If core/model validation behavior changed, update `spec-notes/webauthn-l3-validation-map.md`.
 7. If core/security-critical modules changed, update `docs/IMPLEMENTATION_STATUS.md` and/or `docs/ROADMAP.md`.
 8. When a published module implementation/build contract changes, update the matching module `README.md` in the same change.
@@ -52,6 +53,25 @@ Only when the API change is intentional, regenerate baselines and re-check:
 ```bash
 ./gradlew publishToMavenLocal --stacktrace
 ```
+
+## PR Change Profile Workflow
+
+`.github/workflows/pr-change-profile.yml` maintains one marker comment that
+summarizes changed-file churn by review-oriented category, module, and platform
+source set. The profile is descriptive review context, not a test-coverage
+metric or a quality gate.
+
+Repository path classification is customized in
+`.github/pr-change-profile.config.json`. Source-like files that do not match a
+known layout remain visible as `Unclassified source` instead of being silently
+folded into another category. Changes to the profiler, its configuration, or its
+workflow are covered by the unprivileged
+`.github/workflows/pr-change-profile-selftest.yml` workflow.
+
+The commenting workflow uses `pull_request_target` only to support fork pull
+requests. It loads the profiler and configuration from the trusted default
+branch, never checks out or executes the pull request head, and renders pull
+request file data obtained through the GitHub API.
 
 ## Docs-Only Workflow
 

--- a/documentation/example-inventory.md
+++ b/documentation/example-inventory.md
@@ -68,14 +68,14 @@ Managed blocks: **111**
 | docs-ai-workflows-bash-1 | docs/ai/WORKFLOWS.md:10 | Standard Change Workflow | bash | contributor | markdown | Markdown block | syntax |  |
 | docs-ai-workflows-bash-2 | docs/ai/WORKFLOWS.md:17 | Standard Change Workflow | bash | contributor | markdown | Markdown block | syntax |  |
 | docs-ai-workflows-bash-3 | docs/ai/WORKFLOWS.md:24 | Standard Change Workflow | bash | contributor | markdown | Markdown block | syntax |  |
-| docs-ai-workflows-bash-4 | docs/ai/WORKFLOWS.md:38 | Standard Change Workflow | bash | contributor | markdown | Markdown block | syntax |  |
-| docs-ai-workflows-bash-5 | docs/ai/WORKFLOWS.md:45 | Standard Change Workflow | bash | contributor | markdown | Markdown block | syntax |  |
-| docs-ai-workflows-bash-6 | docs/ai/WORKFLOWS.md:52 | Standard Change Workflow | bash | contributor | markdown | Markdown block | syntax |  |
-| docs-ai-workflows-bash-7 | docs/ai/WORKFLOWS.md:65 | Public Security Hygiene Workflow | bash | contributor | markdown | Markdown block | syntax |  |
-| docs-ai-workflows-bash-8 | docs/ai/WORKFLOWS.md:72 | Public Security Hygiene Workflow | bash | contributor | markdown | Markdown block | syntax |  |
-| docs-ai-workflows-bash-9 | docs/ai/WORKFLOWS.md:79 | Public Security Hygiene Workflow | bash | contributor | markdown | Markdown block | syntax |  |
-| docs-ai-workflows-bash-10 | docs/ai/WORKFLOWS.md:91 | Full Validation Workflow | bash | contributor | markdown | Markdown block | syntax |  |
-| docs-ai-workflows-bash-11 | docs/ai/WORKFLOWS.md:101 | Release-Prep Workflow | bash | contributor | markdown | Markdown block | syntax |  |
+| docs-ai-workflows-bash-4 | docs/ai/WORKFLOWS.md:39 | Standard Change Workflow | bash | contributor | markdown | Markdown block | syntax |  |
+| docs-ai-workflows-bash-5 | docs/ai/WORKFLOWS.md:46 | Standard Change Workflow | bash | contributor | markdown | Markdown block | syntax |  |
+| docs-ai-workflows-bash-6 | docs/ai/WORKFLOWS.md:53 | Standard Change Workflow | bash | contributor | markdown | Markdown block | syntax |  |
+| docs-ai-workflows-bash-7 | docs/ai/WORKFLOWS.md:85 | Public Security Hygiene Workflow | bash | contributor | markdown | Markdown block | syntax |  |
+| docs-ai-workflows-bash-8 | docs/ai/WORKFLOWS.md:92 | Public Security Hygiene Workflow | bash | contributor | markdown | Markdown block | syntax |  |
+| docs-ai-workflows-bash-9 | docs/ai/WORKFLOWS.md:99 | Public Security Hygiene Workflow | bash | contributor | markdown | Markdown block | syntax |  |
+| docs-ai-workflows-bash-10 | docs/ai/WORKFLOWS.md:111 | Full Validation Workflow | bash | contributor | markdown | Markdown block | syntax |  |
+| docs-ai-workflows-bash-11 | docs/ai/WORKFLOWS.md:121 | Release-Prep Workflow | bash | contributor | markdown | Markdown block | syntax |  |
 | docs-architecture-mermaid-1 | docs/architecture.md:32 | Reference integration | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
 | docs-architecture-mermaid-2 | docs/architecture.md:58 | Shared foundation | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
 | docs-architecture-mermaid-3 | docs/architecture.md:91 | Client stack | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |


### PR DESCRIPTION
## Summary

- Add a repository-aware PR change profiler for published source, tests, samples, documentation, tooling, publishing metadata, API baselines, and generated/reference material.
- Report category totals, per-module churn, and KMP source-set/platform distribution in one sticky PR comment and the Actions job summary.
- Keep repository path rules configurable in `.github/pr-change-profile.config.json`, while surfacing unmatched source-like paths explicitly.
- Add a read-only self-test workflow with refactored-module fixtures and create, update, escaping, and incomplete-list coverage.

## Refactored architecture alignment

The classifier fixtures exercise the consolidated `webauthn-client-platform` Android/iOS source sets and the new `webauthn-client-flow`, `webauthn-client-ktor-kotlinx`, and `webauthn-json-api` modules. Published modules remain layout-driven under `core/`, `client/`, and `server/`, avoiding a hard-coded artifact list.

## Security model

The commenting workflow uses `pull_request_target` only so fork PRs can receive comments. It checks out the profiler and configuration from the repository's trusted default branch, never checks out or executes the PR head, and consumes PR changes only through GitHub API metadata. Permissions are limited to `contents: read` and `pull-requests: write`.

PR-controlled file and branch metadata is escaped before Markdown rendering. The self-test workflow runs on ordinary `pull_request` with read-only permissions. These boundaries are also documented in `SECURITY.md`, the public-launch checklist, and the contributor workflow guide.

## Behavior

The sticky comment shows:

- category-level file/add/delete/churn/share totals;
- published-source versus test/verification change volume;
- published changes by module and platform/source set;
- warnings for unclassified source-like paths;
- an explicit warning when GitHub returns fewer file records than the PR reports.

Change volume is intentionally described as review context, not test coverage or a quality gate.

## Validation

- `node --test .github/scripts/pr-change-profile.test.cjs` — 45/45 passing
- `./gradlew docsUpdate --stacktrace`
- `tools/agent/quality-gate.sh --mode strict --scope changed --block false`
- `git diff --check origin/main...HEAD`

## Rollout and possible extraction

After merge, existing open PRs can be backfilled with the workflow's `workflow_dispatch` `pr_number` input. New and updated PRs run on `opened`, `synchronize`, `reopened`, `ready_for_review`, and `edited`.

This PR deliberately keeps the first version repository-local. If its categories and comment shape prove useful in normal review, the next step can extract the pure classifier/renderer into a reusable package and publish a small GitHub Action whose inputs cover category labels/order, path rules, comment marker/title, module roots, and optional sections.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated pull request change profiles with categorized file, module, platform, and change-volume summaries.
  * Reports are posted to pull requests and GitHub workflow summaries, with warnings for incomplete or unclassified changes.

* **Tests**
  * Added comprehensive automated coverage for classification, aggregation, reporting, escaping, and comment updates.
  * Added a workflow to run profiler tests when related files change.

* **Documentation**
  * Documented secure execution requirements and the change-profile workflow.
  * Updated the generated example inventory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->