### PR TITLE
refactor(client): stabilize passkey error surface

### DIFF
--- a/client/webauthn-client-core/README.md
+++ b/client/webauthn-client-core/README.md
@@ -10,6 +10,8 @@ Platform-neutral passkey operations and result/error contracts at the raw platfo
 
 `PasskeyPlatformBridge` is the public SPI for custom target-specific integrations. Application code should normally depend on `PasskeyClient` or the platform/defaults modules instead.
 
+`PasskeyClientError` is a stable, message-only cross-platform surface: it classifies cancellation, no-credential, invalid-options, transport, and platform failures without exposing platform `Throwable` instances.
+
 Use `webauthn-client-flow` when the application also needs start → prompt → finish orchestration.
 
 ## Status

--- a/client/webauthn-client-core/api/webauthn-client-core.api
+++ b/client/webauthn-client-core/api/webauthn-client-core.api
@@ -74,29 +74,36 @@ public final class dev/webauthn/client/PasskeyClientError$InvalidOptions : dev/w
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/webauthn/client/PasskeyClientError$Platform : dev/webauthn/client/PasskeyClientError {
-	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class dev/webauthn/client/PasskeyClientError$NoCredential : dev/webauthn/client/PasskeyClientError {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/Throwable;
-	public final fun copy (Ljava/lang/String;Ljava/lang/Throwable;)Ldev/webauthn/client/PasskeyClientError$Platform;
-	public static synthetic fun copy$default (Ldev/webauthn/client/PasskeyClientError$Platform;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)Ldev/webauthn/client/PasskeyClientError$Platform;
+	public final fun copy (Ljava/lang/String;)Ldev/webauthn/client/PasskeyClientError$NoCredential;
+	public static synthetic fun copy$default (Ldev/webauthn/client/PasskeyClientError$NoCredential;Ljava/lang/String;ILjava/lang/Object;)Ldev/webauthn/client/PasskeyClientError$NoCredential;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getCause ()Ljava/lang/Throwable;
+	public fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/webauthn/client/PasskeyClientError$Platform : dev/webauthn/client/PasskeyClientError {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Ldev/webauthn/client/PasskeyClientError$Platform;
+	public static synthetic fun copy$default (Ldev/webauthn/client/PasskeyClientError$Platform;Ljava/lang/String;ILjava/lang/Object;)Ldev/webauthn/client/PasskeyClientError$Platform;
+	public fun equals (Ljava/lang/Object;)Z
 	public fun getMessage ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class dev/webauthn/client/PasskeyClientError$Transport : dev/webauthn/client/PasskeyClientError {
-	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/Throwable;
-	public final fun copy (Ljava/lang/String;Ljava/lang/Throwable;)Ldev/webauthn/client/PasskeyClientError$Transport;
-	public static synthetic fun copy$default (Ldev/webauthn/client/PasskeyClientError$Transport;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)Ldev/webauthn/client/PasskeyClientError$Transport;
+	public final fun copy (Ljava/lang/String;)Ldev/webauthn/client/PasskeyClientError$Transport;
+	public static synthetic fun copy$default (Ldev/webauthn/client/PasskeyClientError$Transport;Ljava/lang/String;ILjava/lang/Object;)Ldev/webauthn/client/PasskeyClientError$Transport;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getCause ()Ljava/lang/Throwable;
 	public fun getMessage ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/client/webauthn-client-core/api/webauthn-client-core.klib.api
+++ b/client/webauthn-client-core/api/webauthn-client-core.klib.api
@@ -64,33 +64,40 @@ sealed interface dev.webauthn.client/PasskeyClientError { // dev.webauthn.client
         final fun toString(): kotlin/String // dev.webauthn.client/PasskeyClientError.InvalidOptions.toString|toString(){}[0]
     }
 
-    final class Platform : dev.webauthn.client/PasskeyClientError { // dev.webauthn.client/PasskeyClientError.Platform|null[0]
-        constructor <init>(kotlin/String, kotlin/Throwable? = ...) // dev.webauthn.client/PasskeyClientError.Platform.<init>|<init>(kotlin.String;kotlin.Throwable?){}[0]
+    final class NoCredential : dev.webauthn.client/PasskeyClientError { // dev.webauthn.client/PasskeyClientError.NoCredential|null[0]
+        constructor <init>(kotlin/String = ...) // dev.webauthn.client/PasskeyClientError.NoCredential.<init>|<init>(kotlin.String){}[0]
 
-        final val cause // dev.webauthn.client/PasskeyClientError.Platform.cause|{}cause[0]
-            final fun <get-cause>(): kotlin/Throwable? // dev.webauthn.client/PasskeyClientError.Platform.cause.<get-cause>|<get-cause>(){}[0]
+        final val message // dev.webauthn.client/PasskeyClientError.NoCredential.message|{}message[0]
+            final fun <get-message>(): kotlin/String // dev.webauthn.client/PasskeyClientError.NoCredential.message.<get-message>|<get-message>(){}[0]
+
+        final fun component1(): kotlin/String // dev.webauthn.client/PasskeyClientError.NoCredential.component1|component1(){}[0]
+        final fun copy(kotlin/String = ...): dev.webauthn.client/PasskeyClientError.NoCredential // dev.webauthn.client/PasskeyClientError.NoCredential.copy|copy(kotlin.String){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // dev.webauthn.client/PasskeyClientError.NoCredential.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // dev.webauthn.client/PasskeyClientError.NoCredential.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // dev.webauthn.client/PasskeyClientError.NoCredential.toString|toString(){}[0]
+    }
+
+    final class Platform : dev.webauthn.client/PasskeyClientError { // dev.webauthn.client/PasskeyClientError.Platform|null[0]
+        constructor <init>(kotlin/String) // dev.webauthn.client/PasskeyClientError.Platform.<init>|<init>(kotlin.String){}[0]
+
         final val message // dev.webauthn.client/PasskeyClientError.Platform.message|{}message[0]
             final fun <get-message>(): kotlin/String // dev.webauthn.client/PasskeyClientError.Platform.message.<get-message>|<get-message>(){}[0]
 
         final fun component1(): kotlin/String // dev.webauthn.client/PasskeyClientError.Platform.component1|component1(){}[0]
-        final fun component2(): kotlin/Throwable? // dev.webauthn.client/PasskeyClientError.Platform.component2|component2(){}[0]
-        final fun copy(kotlin/String = ..., kotlin/Throwable? = ...): dev.webauthn.client/PasskeyClientError.Platform // dev.webauthn.client/PasskeyClientError.Platform.copy|copy(kotlin.String;kotlin.Throwable?){}[0]
+        final fun copy(kotlin/String = ...): dev.webauthn.client/PasskeyClientError.Platform // dev.webauthn.client/PasskeyClientError.Platform.copy|copy(kotlin.String){}[0]
         final fun equals(kotlin/Any?): kotlin/Boolean // dev.webauthn.client/PasskeyClientError.Platform.equals|equals(kotlin.Any?){}[0]
         final fun hashCode(): kotlin/Int // dev.webauthn.client/PasskeyClientError.Platform.hashCode|hashCode(){}[0]
         final fun toString(): kotlin/String // dev.webauthn.client/PasskeyClientError.Platform.toString|toString(){}[0]
     }
 
     final class Transport : dev.webauthn.client/PasskeyClientError { // dev.webauthn.client/PasskeyClientError.Transport|null[0]
-        constructor <init>(kotlin/String, kotlin/Throwable? = ...) // dev.webauthn.client/PasskeyClientError.Transport.<init>|<init>(kotlin.String;kotlin.Throwable?){}[0]
+        constructor <init>(kotlin/String) // dev.webauthn.client/PasskeyClientError.Transport.<init>|<init>(kotlin.String){}[0]
 
-        final val cause // dev.webauthn.client/PasskeyClientError.Transport.cause|{}cause[0]
-            final fun <get-cause>(): kotlin/Throwable? // dev.webauthn.client/PasskeyClientError.Transport.cause.<get-cause>|<get-cause>(){}[0]
         final val message // dev.webauthn.client/PasskeyClientError.Transport.message|{}message[0]
             final fun <get-message>(): kotlin/String // dev.webauthn.client/PasskeyClientError.Transport.message.<get-message>|<get-message>(){}[0]
 
         final fun component1(): kotlin/String // dev.webauthn.client/PasskeyClientError.Transport.component1|component1(){}[0]
-        final fun component2(): kotlin/Throwable? // dev.webauthn.client/PasskeyClientError.Transport.component2|component2(){}[0]
-        final fun copy(kotlin/String = ..., kotlin/Throwable? = ...): dev.webauthn.client/PasskeyClientError.Transport // dev.webauthn.client/PasskeyClientError.Transport.copy|copy(kotlin.String;kotlin.Throwable?){}[0]
+        final fun copy(kotlin/String = ...): dev.webauthn.client/PasskeyClientError.Transport // dev.webauthn.client/PasskeyClientError.Transport.copy|copy(kotlin.String){}[0]
         final fun equals(kotlin/Any?): kotlin/Boolean // dev.webauthn.client/PasskeyClientError.Transport.equals|equals(kotlin.Any?){}[0]
         final fun hashCode(): kotlin/Int // dev.webauthn.client/PasskeyClientError.Transport.hashCode|hashCode(){}[0]
         final fun toString(): kotlin/String // dev.webauthn.client/PasskeyClientError.Transport.toString|toString(){}[0]

--- a/client/webauthn-client-core/src/commonMain/kotlin/dev/webauthn/client/PasskeyClientError.kt
+++ b/client/webauthn-client-core/src/commonMain/kotlin/dev/webauthn/client/PasskeyClientError.kt
@@ -11,12 +11,17 @@ public sealed interface PasskeyClientError {
         override val message: String = "The user cancelled the passkey prompt",
     ) : PasskeyClientError
 
+    /** The selected provider had no credential available for the requested assertion. */
+    public data class NoCredential(
+        override val message: String = "No passkey credential was available",
+    ) : PasskeyClientError
+
     /** The caller supplied invalid inputs, or the platform rejected options before prompting. */
     public data class InvalidOptions(override val message: String) : PasskeyClientError
 
     /** The ceremony could not be completed because a backend or other transport dependency failed. */
-    public data class Transport(override val message: String, public val cause: Throwable? = null) : PasskeyClientError
+    public data class Transport(override val message: String) : PasskeyClientError
 
     /** The platform passkey provider failed for a non-transport reason. */
-    public data class Platform(override val message: String, public val cause: Throwable? = null) : PasskeyClientError
+    public data class Platform(override val message: String) : PasskeyClientError
 }

--- a/client/webauthn-client-core/src/commonTest/kotlin/dev/webauthn/client/DefaultPasskeyClientTest.kt
+++ b/client/webauthn-client-core/src/commonTest/kotlin/dev/webauthn/client/DefaultPasskeyClientTest.kt
@@ -55,7 +55,7 @@ class DefaultPasskeyClientTest {
         val client = DefaultPasskeyClient(
             bridge = TestBridge(
                 assertionAction = { error("boom") },
-                errorMapper = { PasskeyClientError.Transport("mapped", it) },
+                errorMapper = { PasskeyClientError.Transport("mapped") },
             ),
         )
 
@@ -109,7 +109,7 @@ class DefaultPasskeyClientTest {
         val client = DefaultPasskeyClient(
             bridge = TestBridge(
                 createAction = { throw IllegalArgumentException("bad options") },
-                errorMapper = { PasskeyClientError.Platform("unexpected", it) },
+                errorMapper = { PasskeyClientError.Platform("unexpected") },
             ),
         )
 
@@ -141,7 +141,7 @@ class DefaultPasskeyClientTest {
         val client = DefaultPasskeyClient(
             bridge = TestBridge(
                 createAction = { error("bridge failure") },
-                errorMapper = { PasskeyClientError.Transport("mapped", it) },
+                errorMapper = { PasskeyClientError.Transport("mapped") },
             ),
         )
 
@@ -352,7 +352,7 @@ class DefaultPasskeyClientTest {
     private class TestBridge(
         private val createAction: suspend (PublicKeyCredentialCreationOptions) -> RawRegistrationResponse = { validRawRegistrationResponse() },
         private val assertionAction: suspend (PublicKeyCredentialRequestOptions) -> RawAuthenticationResponse = { validRawAuthenticationResponse() },
-        private val errorMapper: (Throwable) -> PasskeyClientError = { PasskeyClientError.Platform(it.message ?: "platform", it) },
+        private val errorMapper: (Throwable) -> PasskeyClientError = { PasskeyClientError.Platform(it.message ?: "platform") },
         private val capabilitiesAction: suspend () -> PasskeyCapabilities = { PasskeyCapabilities() },
     ) : PasskeyPlatformBridge {
         override suspend fun createCredential(options: PublicKeyCredentialCreationOptions): RawRegistrationResponse = createAction(options)

--- a/client/webauthn-client-flow/src/commonMain/kotlin/dev/webauthn/client/PasskeyController.kt
+++ b/client/webauthn-client-flow/src/commonMain/kotlin/dev/webauthn/client/PasskeyController.kt
@@ -96,7 +96,7 @@ public class PasskeyController<RegisterParams, SignInParams>(
             e.rethrowCancellation()
             val error = when (e) {
                 is IllegalArgumentException -> PasskeyClientError.InvalidOptions(e.message ?: "Invalid options")
-                else -> PasskeyClientError.Transport(e.message ?: "Server interaction failed", e)
+                else -> PasskeyClientError.Transport(e.message ?: "Server interaction failed")
             }
             uiState.value = PasskeyControllerState.Failure(action, error)
         } finally {

--- a/client/webauthn-client-json-core/src/commonMain/kotlin/dev/webauthn/client/JsonPasskeyClient.kt
+++ b/client/webauthn-client-json-core/src/commonMain/kotlin/dev/webauthn/client/JsonPasskeyClient.kt
@@ -65,10 +65,7 @@ public class DefaultJsonPasskeyClient(
                 onSuccess = { PasskeyResult.Success(it) },
                 onFailure = { error ->
                     PasskeyResult.Failure(
-                        PasskeyClientError.Platform(
-                            "$encodeErrorMessage: ${error.message ?: "unknown error"}",
-                            error,
-                        ),
+                        PasskeyClientError.Platform("$encodeErrorMessage: ${error.message ?: "unknown error"}"),
                     )
                 },
             )

--- a/client/webauthn-client-platform/README.md
+++ b/client/webauthn-client-platform/README.md
@@ -69,6 +69,7 @@ flowchart LR
   - `PasskeyCapability.Extension(WebAuthnExtension.Prf)` when PRF is supported.
   - `PasskeyCapability.Extension(WebAuthnExtension.LargeBlob)` when largeBlob is supported.
   - `PasskeyCapability.PlatformFeature("securityKey")` when cross-platform security keys are supported.
+- A provider with no matching credential is reported as `PasskeyClientError.NoCredential`; other provider failures expose a stable message without leaking OS exception objects.
 - Keep backend contract alignment with your chosen server client implementation.
 - If the platform reports `RP ID cannot be validated`, verify:
   - RP ID and HTTPS origin/domain alignment.

--- a/client/webauthn-client-platform/src/androidHostTest/kotlin/dev/webauthn/client/android/AndroidPasskeyClientTest.kt
+++ b/client/webauthn-client-platform/src/androidHostTest/kotlin/dev/webauthn/client/android/AndroidPasskeyClientTest.kt
@@ -142,7 +142,7 @@ class AndroidPasskeyClientTest {
     }
 
     @Test
-    fun getAssertion_returns_Platform_error_on_NoCredentialException() = runBlocking {
+    fun getAssertion_returns_NoCredential_on_NoCredentialException() = runBlocking {
         val mockCredentialManager = mockk<CredentialManager>(relaxed = true)
         val client = testClient(credentialManager = mockCredentialManager)
 
@@ -159,8 +159,8 @@ class AndroidPasskeyClientTest {
         val result = client.getAssertion(options)
         assertTrue(result is PasskeyResult.Failure)
         val failure = result as PasskeyResult.Failure
-        assertTrue(failure.error is PasskeyClientError.Platform)
-        assertEquals("No credentials found", failure.error.message)
+        assertTrue(failure.error is PasskeyClientError.NoCredential)
+        assertEquals("No passkey credential was available", failure.error.message)
     }
 
     @Test

--- a/client/webauthn-client-platform/src/androidMain/kotlin/dev/webauthn/client/android/AndroidPasskeyClient.kt
+++ b/client/webauthn-client-platform/src/androidMain/kotlin/dev/webauthn/client/android/AndroidPasskeyClient.kt
@@ -145,13 +145,12 @@ internal class AndroidPasskeyPlatformBridge(
     override fun mapPlatformError(throwable: Throwable): PasskeyClientError = when (throwable) {
         is CreateCredentialCancellationException,
         is GetCredentialCancellationException -> PasskeyClientError.UserCancelled()
-        is NoCredentialException -> PasskeyClientError.Platform("No credentials found")
+        is NoCredentialException -> PasskeyClientError.NoCredential()
         is IllegalArgumentException -> PasskeyClientError.InvalidOptions(
             enrichRpIdValidationMessage(throwable.message ?: "Invalid options"),
         )
         else -> PasskeyClientError.Platform(
             enrichRpIdValidationMessage(throwable.message ?: "Unknown platform error"),
-            throwable,
         )
     }
 

--- a/client/webauthn-client-platform/src/iosMain/kotlin/dev/webauthn/client/ios/IosErrorMapping.kt
+++ b/client/webauthn-client-platform/src/iosMain/kotlin/dev/webauthn/client/ios/IosErrorMapping.kt
@@ -14,15 +14,15 @@ internal fun NSError.toPasskeyClientError(): PasskeyClientError {
         when (this.code) {
             ASAuthorizationErrorCanceled -> return PasskeyClientError.UserCancelled()
             ASAuthorizationErrorNotHandled -> {
-                return PasskeyClientError.Platform("Request not handled", NSErrorException(this))
+                return PasskeyClientError.Platform("Request not handled")
             }
 
             ASAuthorizationErrorFailed -> {
-                return PasskeyClientError.Platform("Authorization failed", NSErrorException(this))
+                return PasskeyClientError.Platform("Authorization failed")
             }
 
-            else -> return PasskeyClientError.Platform(this.localizedDescription, NSErrorException(this))
+            else -> return PasskeyClientError.Platform(this.localizedDescription)
         }
     }
-    return PasskeyClientError.Platform(this.localizedDescription, NSErrorException(this))
+    return PasskeyClientError.Platform(this.localizedDescription)
 }

--- a/client/webauthn-client-platform/src/iosMain/kotlin/dev/webauthn/client/ios/IosPasskeyClientImpl.kt
+++ b/client/webauthn-client-platform/src/iosMain/kotlin/dev/webauthn/client/ios/IosPasskeyClientImpl.kt
@@ -76,7 +76,7 @@ internal class IosPasskeyPlatformBridge(
         return when (throwable) {
             is NSErrorException -> throwable.error.toPasskeyClientError()
             is IllegalArgumentException -> PasskeyClientError.InvalidOptions(throwable.message ?: "Invalid options")
-            else -> PasskeyClientError.Platform(throwable.message ?: "Unknown platform error", throwable)
+            else -> PasskeyClientError.Platform(throwable.message ?: "Unknown platform error")
         }
     }
 

--- a/client/webauthn-client-prf-crypto/src/commonMain/kotlin/dev/webauthn/client/prf/PrfCryptoClient.kt
+++ b/client/webauthn-client-prf-crypto/src/commonMain/kotlin/dev/webauthn/client/prf/PrfCryptoClient.kt
@@ -74,10 +74,7 @@ private fun Throwable.toFailure(): PasskeyResult.Failure {
 
         else -> {
             PasskeyResult.Failure(
-                PasskeyClientError.Platform(
-                    message = nonFatal.message ?: "PRF crypto operation failed",
-                    cause = nonFatal,
-                ),
+                PasskeyClientError.Platform(nonFatal.message ?: "PRF crypto operation failed"),
             )
         }
     }

--- a/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/domain/passkey/PasskeyDemoFlow.kt
+++ b/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/domain/passkey/PasskeyDemoFlow.kt
@@ -119,6 +119,7 @@ internal fun controllerTransitionEvent(
 private enum class PasskeyDemoErrorCategory(val label: String) {
     INVALID_OPTIONS("Invalid Options"),
     USER_CANCELLED("User Cancelled"),
+    NO_CREDENTIAL("No Credential"),
     PLATFORM("Platform"),
     TRANSPORT("Transport"),
 }
@@ -127,6 +128,7 @@ private fun PasskeyClientError.toCategory(): PasskeyDemoErrorCategory {
     return when (this) {
         is PasskeyClientError.InvalidOptions -> PasskeyDemoErrorCategory.INVALID_OPTIONS
         is PasskeyClientError.UserCancelled -> PasskeyDemoErrorCategory.USER_CANCELLED
+        is PasskeyClientError.NoCredential -> PasskeyDemoErrorCategory.NO_CREDENTIAL
         is PasskeyClientError.Platform -> PasskeyDemoErrorCategory.PLATFORM
         is PasskeyClientError.Transport -> PasskeyDemoErrorCategory.TRANSPORT
     }


### PR DESCRIPTION
Part of the client-refactor stack; targets #237.

Stabilizes the public passkey error model:
- removes public `Throwable` causes from platform and transport error values;
- adds the explicit `PasskeyClientError.NoCredential` classification for Android Credential Manager;
- keeps provider diagnostics as stable cross-platform messages and updates the sample’s UX category.

API baselines and consumer docs capture the breaking error-surface change.

Verified with:
- client core/flow/JSON/platform/PRF suites
- Compose sample suite and docs check
- strict changed-scope quality gate
- `apiCheck docsCheck publishToMavenLocal`