### PR TITLE
refactor(ktor): introduce typed backend contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Use:
 - [`webauthn-client-platform`](./client/webauthn-client-platform/README.md)
 - [`webauthn-client-compose`](./client/webauthn-client-compose/README.md) for Compose helpers
 - [`webauthn-client-prf-crypto`](./client/webauthn-client-prf-crypto/README.md) for PRF-based key derivation and encryption helpers
-- [`webauthn-client-ktor`](./client/webauthn-client-ktor/README.md) for the default backend contract (`HttpClient`-based API; add your preferred Ktor engine at app runtime)
+- [`webauthn-client-ktor`](./client/webauthn-client-ktor/README.md) for codec-neutral Ktor backend transport, plus `webauthn-client-ktor-kotlinx` for the default contract
 
 ### End-to-end reference app
 
@@ -262,7 +262,8 @@ Desktop and CLI strategy notes for this repo live in [`docs/DESKTOP_CLI_STRATEGY
 | [`webauthn-client-compose`](./client/webauthn-client-compose/README.md) | Compose apps that want remembered client/controller helpers |
 | [`webauthn-client-platform`](./client/webauthn-client-platform/README.md) | Android apps using Credential Manager or iOS apps using AuthenticationServices |
 | [`webauthn-client-prf-crypto`](./client/webauthn-client-prf-crypto/README.md) | Client apps deriving crypto sessions from WebAuthn PRF extension outputs |
-| [`webauthn-client-ktor`](./client/webauthn-client-ktor/README.md) | Clients talking to a `/webauthn/*` backend contract over Ktor (`HttpClient` contract + caller-selected engine) |
+| [`webauthn-client-ktor`](./client/webauthn-client-ktor/README.md) | Clients composing a typed Ktor transport with their own backend-contract codec; legacy default client remains during migration |
+| `webauthn-client-ktor-kotlinx` | Apps using the default `/webauthn/…` contract with Kotlinx Serialization |
 | [`webauthn-attestation-mds`](./server/webauthn-attestation-mds/README.md) | Backends that want optional FIDO Metadata Service trust anchors |
 
 ## Status and Current Limits

--- a/client/webauthn-client-ktor-kotlinx/README.md
+++ b/client/webauthn-client-ktor-kotlinx/README.md
@@ -1,0 +1,7 @@
+# webauthn-client-ktor-kotlinx
+
+Kotlinx Serialization implementation of the default Ktor passkey backend contract.
+
+Use this only with the default `/webauthn/…` payload shape. Apps that use another JSON library or
+backend contract should depend on `webauthn-client-ktor` and provide their own
+`KtorPasskeyContractCodec` implementation.

--- a/client/webauthn-client-ktor-kotlinx/api/webauthn-client-ktor-kotlinx.api
+++ b/client/webauthn-client-ktor-kotlinx/api/webauthn-client-ktor-kotlinx.api
@@ -1,0 +1,22 @@
+public final class dev/webauthn/network/kotlinx/KotlinxKtorPasskeyBackend {
+	public fun <init> (Lio/ktor/client/HttpClient;Ljava/lang/String;Ldev/webauthn/network/KtorPasskeyRoutes;)V
+	public synthetic fun <init> (Lio/ktor/client/HttpClient;Ljava/lang/String;Ldev/webauthn/network/KtorPasskeyRoutes;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun authenticationBackend ()Ldev/webauthn/client/AuthenticationBackend;
+	public final fun registrationBackend ()Ldev/webauthn/client/RegistrationBackend;
+}
+public final class dev/webauthn/network/kotlinx/KotlinxKtorPasskeyContractCodec : dev/webauthn/network/KtorPasskeyContractCodec {
+	public fun <init> ()V
+	public fun decodeAuthenticationFinish (Ljava/lang/String;)Ldev/webauthn/client/PasskeyFinishResult;
+	public synthetic fun decodeAuthenticationFinish (Ljava/lang/String;)Ljava/lang/Object;
+	public fun decodeAuthenticationStart (Ljava/lang/String;)Ldev/webauthn/model/ValidationResult;
+	public fun decodeError (Ljava/lang/String;)Ljava/lang/String;
+	public fun decodeRegistrationFinish (Ljava/lang/String;)Ldev/webauthn/client/PasskeyFinishResult;
+	public synthetic fun decodeRegistrationFinish (Ljava/lang/String;)Ljava/lang/Object;
+	public fun decodeRegistrationStart (Ljava/lang/String;)Ldev/webauthn/model/ValidationResult;
+	public fun encodeAuthenticationFinish (Ldev/webauthn/model/RawAuthenticationResponse;)Ljava/lang/String;
+	public fun encodeAuthenticationStart (Ldev/webauthn/network/AuthenticationStartPayload;)Ljava/lang/String;
+	public synthetic fun encodeAuthenticationStart (Ljava/lang/Object;)Ljava/lang/String;
+	public fun encodeRegistrationFinish (Ldev/webauthn/model/RawRegistrationResponse;)Ljava/lang/String;
+	public fun encodeRegistrationStart (Ldev/webauthn/network/RegistrationStartPayload;)Ljava/lang/String;
+	public synthetic fun encodeRegistrationStart (Ljava/lang/Object;)Ljava/lang/String;
+}

--- a/client/webauthn-client-ktor-kotlinx/api/webauthn-client-ktor-kotlinx.klib.api
+++ b/client/webauthn-client-ktor-kotlinx/api/webauthn-client-ktor-kotlinx.klib.api
@@ -1,0 +1,28 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <io.github.szijpeter:webauthn-client-ktor-kotlinx>
+final class dev.webauthn.network.kotlinx/KotlinxKtorPasskeyBackend { // dev.webauthn.network.kotlinx/KotlinxKtorPasskeyBackend|null[0]
+    constructor <init>(io.ktor.client/HttpClient, kotlin/String, dev.webauthn.network/KtorPasskeyRoutes = ...) // dev.webauthn.network.kotlinx/KotlinxKtorPasskeyBackend.<init>|<init>(io.ktor.client.HttpClient;kotlin.String;dev.webauthn.network.KtorPasskeyRoutes){}[0]
+
+    final fun authenticationBackend(): dev.webauthn.client/AuthenticationBackend<dev.webauthn.network/AuthenticationStartPayload, kotlin/Unit, dev.webauthn.client/PasskeyFinishResult> // dev.webauthn.network.kotlinx/KotlinxKtorPasskeyBackend.authenticationBackend|authenticationBackend(){}[0]
+    final fun registrationBackend(): dev.webauthn.client/RegistrationBackend<dev.webauthn.network/RegistrationStartPayload, kotlin/Unit, dev.webauthn.client/PasskeyFinishResult> // dev.webauthn.network.kotlinx/KotlinxKtorPasskeyBackend.registrationBackend|registrationBackend(){}[0]
+}
+
+final class dev.webauthn.network.kotlinx/KotlinxKtorPasskeyContractCodec : dev.webauthn.network/KtorPasskeyContractCodec<dev.webauthn.network/RegistrationStartPayload, dev.webauthn.network/AuthenticationStartPayload, dev.webauthn.client/PasskeyFinishResult, dev.webauthn.client/PasskeyFinishResult> { // dev.webauthn.network.kotlinx/KotlinxKtorPasskeyContractCodec|null[0]
+    constructor <init>() // dev.webauthn.network.kotlinx/KotlinxKtorPasskeyContractCodec.<init>|<init>(){}[0]
+
+    final fun decodeAuthenticationFinish(kotlin/String): dev.webauthn.client/PasskeyFinishResult // dev.webauthn.network.kotlinx/KotlinxKtorPasskeyContractCodec.decodeAuthenticationFinish|decodeAuthenticationFinish(kotlin.String){}[0]
+    final fun decodeAuthenticationStart(kotlin/String): dev.webauthn.model/ValidationResult<dev.webauthn.model/PublicKeyCredentialRequestOptions> // dev.webauthn.network.kotlinx/KotlinxKtorPasskeyContractCodec.decodeAuthenticationStart|decodeAuthenticationStart(kotlin.String){}[0]
+    final fun decodeError(kotlin/String): kotlin/String? // dev.webauthn.network.kotlinx/KotlinxKtorPasskeyContractCodec.decodeError|decodeError(kotlin.String){}[0]
+    final fun decodeRegistrationFinish(kotlin/String): dev.webauthn.client/PasskeyFinishResult // dev.webauthn.network.kotlinx/KotlinxKtorPasskeyContractCodec.decodeRegistrationFinish|decodeRegistrationFinish(kotlin.String){}[0]
+    final fun decodeRegistrationStart(kotlin/String): dev.webauthn.model/ValidationResult<dev.webauthn.model/PublicKeyCredentialCreationOptions> // dev.webauthn.network.kotlinx/KotlinxKtorPasskeyContractCodec.decodeRegistrationStart|decodeRegistrationStart(kotlin.String){}[0]
+    final fun encodeAuthenticationFinish(dev.webauthn.model/RawAuthenticationResponse): kotlin/String // dev.webauthn.network.kotlinx/KotlinxKtorPasskeyContractCodec.encodeAuthenticationFinish|encodeAuthenticationFinish(dev.webauthn.model.RawAuthenticationResponse){}[0]
+    final fun encodeAuthenticationStart(dev.webauthn.network/AuthenticationStartPayload): kotlin/String // dev.webauthn.network.kotlinx/KotlinxKtorPasskeyContractCodec.encodeAuthenticationStart|encodeAuthenticationStart(dev.webauthn.network.AuthenticationStartPayload){}[0]
+    final fun encodeRegistrationFinish(dev.webauthn.model/RawRegistrationResponse): kotlin/String // dev.webauthn.network.kotlinx/KotlinxKtorPasskeyContractCodec.encodeRegistrationFinish|encodeRegistrationFinish(dev.webauthn.model.RawRegistrationResponse){}[0]
+    final fun encodeRegistrationStart(dev.webauthn.network/RegistrationStartPayload): kotlin/String // dev.webauthn.network.kotlinx/KotlinxKtorPasskeyContractCodec.encodeRegistrationStart|encodeRegistrationStart(dev.webauthn.network.RegistrationStartPayload){}[0]
+}

--- a/client/webauthn-client-ktor-kotlinx/build.gradle.kts
+++ b/client/webauthn-client-ktor-kotlinx/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    id("webauthn.kotlin.multiplatform")
+    id("webauthn.published-library")
+    alias(libs.plugins.kotlin.serialization)
+}
+
+kotlin {
+    jvm()
+    iosArm64()
+    iosSimulatorArm64()
+
+    sourceSets {
+        commonMain.dependencies {
+            api(project(":client:webauthn-client-ktor"))
+            api(project(":core:webauthn-json-kotlinx"))
+            implementation(libs.kotlinx.serialization.json)
+        }
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+        }
+    }
+}

--- a/client/webauthn-client-ktor-kotlinx/src/commonMain/kotlin/dev/webauthn/network/kotlinx/KotlinxKtorPasskeyBackend.kt
+++ b/client/webauthn-client-ktor-kotlinx/src/commonMain/kotlin/dev/webauthn/network/kotlinx/KotlinxKtorPasskeyBackend.kt
@@ -1,0 +1,35 @@
+package dev.webauthn.network.kotlinx
+
+import dev.webauthn.client.AuthenticationBackend
+import dev.webauthn.client.PasskeyFinishResult
+import dev.webauthn.client.RegistrationBackend
+import dev.webauthn.network.AuthenticationStartPayload
+import dev.webauthn.network.KtorPasskeyBackend
+import dev.webauthn.network.KtorPasskeyRoutes
+import dev.webauthn.network.RegistrationStartPayload
+import io.ktor.client.HttpClient
+
+/**
+ * Default typed backend for the `/webauthn/…` HTTP contract using Kotlinx Serialization.
+ *
+ * This is an opt-in composition of [KtorPasskeyBackend] and
+ * [KotlinxKtorPasskeyContractCodec].
+ */
+public class KotlinxKtorPasskeyBackend(
+    httpClient: HttpClient,
+    endpointBase: String,
+    routes: KtorPasskeyRoutes = KtorPasskeyRoutes(),
+) {
+    private val backend = KtorPasskeyBackend(
+        httpClient = httpClient,
+        endpointBase = endpointBase,
+        codec = KotlinxKtorPasskeyContractCodec(),
+        routes = routes,
+    )
+
+    public fun registrationBackend(): RegistrationBackend<RegistrationStartPayload, Unit, PasskeyFinishResult> =
+        backend.registrationBackend()
+
+    public fun authenticationBackend(): AuthenticationBackend<AuthenticationStartPayload, Unit, PasskeyFinishResult> =
+        backend.authenticationBackend()
+}

--- a/client/webauthn-client-ktor-kotlinx/src/commonMain/kotlin/dev/webauthn/network/kotlinx/KotlinxKtorPasskeyContractCodec.kt
+++ b/client/webauthn-client-ktor-kotlinx/src/commonMain/kotlin/dev/webauthn/network/kotlinx/KotlinxKtorPasskeyContractCodec.kt
@@ -1,0 +1,90 @@
+package dev.webauthn.network.kotlinx
+
+import dev.webauthn.client.PasskeyFinishResult
+import dev.webauthn.model.PublicKeyCredentialCreationOptions
+import dev.webauthn.model.PublicKeyCredentialRequestOptions
+import dev.webauthn.model.RawAuthenticationResponse
+import dev.webauthn.model.RawRegistrationResponse
+import dev.webauthn.model.ValidationResult
+import dev.webauthn.network.AuthenticationStartPayload
+import dev.webauthn.network.KtorPasskeyContractCodec
+import dev.webauthn.network.RegistrationStartPayload
+import dev.webauthn.serialization.AuthenticationResponseDto
+import dev.webauthn.serialization.PublicKeyCredentialCreationOptionsDto
+import dev.webauthn.serialization.PublicKeyCredentialRequestOptionsDto
+import dev.webauthn.serialization.RegistrationResponseDto
+import dev.webauthn.serialization.WebAuthnDtoMapper
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/** Kotlinx Serialization codec for the default `/webauthn/…` Ktor backend contract. */
+public class KotlinxKtorPasskeyContractCodec :
+    KtorPasskeyContractCodec<
+        RegistrationStartPayload,
+        AuthenticationStartPayload,
+        PasskeyFinishResult,
+        PasskeyFinishResult,
+    > {
+    override fun encodeRegistrationStart(input: RegistrationStartPayload): String = json.encodeToString(input)
+
+    override fun decodeRegistrationStart(value: String): ValidationResult<PublicKeyCredentialCreationOptions> =
+        WebAuthnDtoMapper.toModel(
+            decodeOrThrow<PublicKeyCredentialCreationOptionsDto>(value, "Registration start response"),
+        )
+
+    override fun encodeRegistrationFinish(response: RawRegistrationResponse): String =
+        json.encodeToString(RegistrationFinishPayload(WebAuthnDtoMapper.fromModel(response)))
+
+    override fun decodeRegistrationFinish(value: String): PasskeyFinishResult =
+        decodeFinish(value, "Registration finish")
+
+    override fun encodeAuthenticationStart(input: AuthenticationStartPayload): String = json.encodeToString(input)
+
+    override fun decodeAuthenticationStart(value: String): ValidationResult<PublicKeyCredentialRequestOptions> =
+        WebAuthnDtoMapper.toModel(
+            decodeOrThrow<PublicKeyCredentialRequestOptionsDto>(value, "Authentication start response"),
+        )
+
+    override fun encodeAuthenticationFinish(response: RawAuthenticationResponse): String =
+        json.encodeToString(AuthenticationFinishPayload(WebAuthnDtoMapper.fromModel(response)))
+
+    override fun decodeAuthenticationFinish(value: String): PasskeyFinishResult =
+        decodeFinish(value, "Authentication finish")
+
+    override fun decodeError(value: String): String? = runCatching {
+        json.decodeFromString<ServerErrorPayload>(value)
+            .errors
+            ?.filter(String::isNotBlank)
+            ?.joinToString("; ")
+            ?.takeIf(String::isNotBlank)
+    }.getOrNull()
+
+    private fun decodeFinish(value: String, operation: String): PasskeyFinishResult {
+        val result = decodeOrThrow<FinishPayloadResponse>(value, "$operation response")
+        return if (result.status == "ok") PasskeyFinishResult.Verified
+        else PasskeyFinishResult.Rejected("$operation was rejected by the server with status '${result.status}'.")
+    }
+
+    private inline fun <reified T> decodeOrThrow(value: String, operation: String): T =
+        runCatching { json.decodeFromString<T>(value) }
+            .getOrElse { error ->
+                throw IllegalStateException(
+                    "$operation could not be parsed: ${error.message}. Body length=${value.length}",
+                )
+            }
+}
+
+@Serializable
+private data class RegistrationFinishPayload(val response: RegistrationResponseDto)
+
+@Serializable
+private data class AuthenticationFinishPayload(val response: AuthenticationResponseDto)
+
+@Serializable
+private data class FinishPayloadResponse(val status: String)
+
+@Serializable
+private data class ServerErrorPayload(val errors: List<String>? = null)
+
+private val json: Json = Json { ignoreUnknownKeys = true }

--- a/client/webauthn-client-ktor-kotlinx/src/commonTest/kotlin/dev/webauthn/network/kotlinx/KotlinxKtorPasskeyContractCodecTest.kt
+++ b/client/webauthn-client-ktor-kotlinx/src/commonTest/kotlin/dev/webauthn/network/kotlinx/KotlinxKtorPasskeyContractCodecTest.kt
@@ -1,0 +1,47 @@
+package dev.webauthn.network.kotlinx
+
+import dev.webauthn.client.PasskeyFinishResult
+import dev.webauthn.model.Base64UrlBytes
+import dev.webauthn.model.CredentialId
+import dev.webauthn.model.PublicKeyCredentialCreationOptions
+import dev.webauthn.model.RawRegistrationResponse
+import dev.webauthn.model.ValidationResult
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class KotlinxKtorPasskeyContractCodecTest {
+    private val codec = KotlinxKtorPasskeyContractCodec()
+
+    @Test
+    fun registrationStart_decodes_typed_options() {
+        val result = codec.decodeRegistrationStart(
+            """{"challenge":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","rp":{"id":"example.com","name":"Example"},"user":{"id":"AQID","name":"alice","displayName":"Alice"},"pubKeyCredParams":[{"type":"public-key","alg":-7}]}""",
+        )
+
+        val valid = assertIs<ValidationResult.Valid<PublicKeyCredentialCreationOptions>>(result)
+        assertEquals("example.com", valid.value.rp.id.value)
+    }
+
+    @Test
+    fun registrationFinish_encodes_raw_response_without_trusted_client_data_fields() {
+        val encoded = codec.encodeRegistrationFinish(
+            RawRegistrationResponse(
+                credentialId = CredentialId.fromBytes(byteArrayOf(1, 2, 3)),
+                clientDataJson = Base64UrlBytes.fromBytes(byteArrayOf(4, 5, 6)),
+                attestationObject = Base64UrlBytes.fromBytes(byteArrayOf(7, 8, 9)),
+            ),
+        )
+
+        assertTrue(encoded.contains("clientDataJSON"))
+        assertTrue(!encoded.contains("challenge"))
+        assertTrue(!encoded.contains("origin"))
+    }
+
+    @Test
+    fun finish_and_error_results_are_decoded_deterministically() {
+        assertEquals(PasskeyFinishResult.Verified, codec.decodeRegistrationFinish("""{"status":"ok"}"""))
+        assertEquals("first; second", codec.decodeError("""{"errors":["first","second"]}"""))
+    }
+}

--- a/client/webauthn-client-ktor/README.md
+++ b/client/webauthn-client-ktor/README.md
@@ -1,11 +1,14 @@
 # webauthn-client-ktor
 
-Default Ktor-based `PasskeyServerClient` transport for `/webauthn/*` server contracts.
+Codec-neutral Ktor transport for typed passkey backends.
+
+`KtorPasskeyServerClient` remains available as the legacy default-contract client while downstream
+consumers migrate to the typed backend and the Kotlinx companion artifact.
 
 ## What it provides
 
-- `KtorPasskeyServerClient`
-- `registrationBackend()` and `authenticationBackend()` adapters for `PasskeyFlow`
+- `KtorPasskeyBackend`, a typed `RegistrationBackend`/`AuthenticationBackend` transport
+- `KtorPasskeyContractCodec`, the serialization boundary for backend contracts
 - `KtorPasskeyRoutes` for path overrides when your backend keeps the default payload semantics
 - Start/finish HTTP call wiring for registration and authentication
 - A drop-in transport module for client orchestration layers
@@ -14,19 +17,26 @@ Default Ktor-based `PasskeyServerClient` transport for `/webauthn/*` server cont
 
 ## When to use
 
-Use this when your backend follows the default `/webauthn/*` contract and your app already uses Ktor client.
+Use this when your app already uses Ktor client and you want to provide the backend's serialization
+contract. For the default `/webauthn/…` contract with Kotlinx Serialization, add
+`webauthn-client-ktor-kotlinx`.
 
 ## How to use
 
 <!-- doc-example: id=client-webauthn-client-ktor-readme-kotlin-1; owner=source; verify=compile; audience=consumer; source=documentation/examples/src/commonMain/kotlin/dev/webauthn/documentation/examples/NetworkClientExample.kt#network-client -->
 ```kotlin
-import dev.webauthn.network.KtorPasskeyServerClient
+import dev.webauthn.network.KtorPasskeyBackend
+import dev.webauthn.network.KtorPasskeyContractCodec
 import io.ktor.client.HttpClient
 
-fun serverClient(httpClient: HttpClient): KtorPasskeyServerClient {
-    return KtorPasskeyServerClient(
+fun <RegistrationInput, AuthenticationInput, RegistrationOutput, AuthenticationOutput> serverClient(
+    httpClient: HttpClient,
+    codec: KtorPasskeyContractCodec<RegistrationInput, AuthenticationInput, RegistrationOutput, AuthenticationOutput>,
+): KtorPasskeyBackend<RegistrationInput, AuthenticationInput, RegistrationOutput, AuthenticationOutput> {
+    return KtorPasskeyBackend(
         httpClient = httpClient,
         endpointBase = "https://example.com",
+        codec = codec,
     )
 }
 ```
@@ -38,14 +48,16 @@ Real-world scenario: a mobile app uses `PasskeyFlow` for platform ceremonies, th
 <!-- doc-example: id=client-webauthn-client-ktor-readme-mermaid-1; owner=illustrative; verify=illustrative; audience=consumer; reason=Diagram is rendered by the Markdown host -->
 ```mermaid
 flowchart LR
-    UI["App UI"] --> CORE["webauthn-client-core controller"]
-    CORE --> NET["KtorPasskeyServerClient"]
+    UI["App UI"] --> FLOW["PasskeyFlow"]
+    FLOW --> NET["KtorPasskeyBackend"]
+    CODEC["KtorPasskeyContractCodec"] --> NET
     NET --> API["Backend /webauthn/* endpoints"]
 ```
 
 ## Pitfalls and limits
 
-- Route/path assumptions are explicit; if your backend payloads differ from the default sample contract, provide your own `PasskeyServerClient` implementation instead of trying to patch this transport.
+- Route/path assumptions are explicit; if your backend payloads differ, implement
+  `KtorPasskeyContractCodec` rather than patching the transport.
 - `AuthenticationStartPayload.userName` is optional to support both identified and discoverable authentication starts on one endpoint.
 - Authentication-start payloads intentionally exclude `userHandle`; registration-start still carries `userHandle`.
 - `RegistrationStartPayload.residentKey` is optional and forwarded to compatible server contracts when present.

--- a/client/webauthn-client-ktor/api/webauthn-client-ktor.api
+++ b/client/webauthn-client-ktor/api/webauthn-client-ktor.api
@@ -37,6 +37,25 @@ public final class dev/webauthn/network/KtorOriginMetadataProvider : dev/webauth
 	public fun getRelatedOrigins-w6KIa9k (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class dev/webauthn/network/KtorPasskeyBackend {
+	public fun <init> (Lio/ktor/client/HttpClient;Ljava/lang/String;Ldev/webauthn/network/KtorPasskeyContractCodec;Ldev/webauthn/network/KtorPasskeyRoutes;)V
+	public synthetic fun <init> (Lio/ktor/client/HttpClient;Ljava/lang/String;Ldev/webauthn/network/KtorPasskeyContractCodec;Ldev/webauthn/network/KtorPasskeyRoutes;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun authenticationBackend ()Ldev/webauthn/client/AuthenticationBackend;
+	public final fun registrationBackend ()Ldev/webauthn/client/RegistrationBackend;
+}
+
+public abstract interface class dev/webauthn/network/KtorPasskeyContractCodec {
+	public abstract fun decodeAuthenticationFinish (Ljava/lang/String;)Ljava/lang/Object;
+	public abstract fun decodeAuthenticationStart (Ljava/lang/String;)Ldev/webauthn/model/ValidationResult;
+	public abstract fun decodeError (Ljava/lang/String;)Ljava/lang/String;
+	public abstract fun decodeRegistrationFinish (Ljava/lang/String;)Ljava/lang/Object;
+	public abstract fun decodeRegistrationStart (Ljava/lang/String;)Ldev/webauthn/model/ValidationResult;
+	public abstract fun encodeAuthenticationFinish (Ldev/webauthn/model/RawAuthenticationResponse;)Ljava/lang/String;
+	public abstract fun encodeAuthenticationStart (Ljava/lang/Object;)Ljava/lang/String;
+	public abstract fun encodeRegistrationFinish (Ldev/webauthn/model/RawRegistrationResponse;)Ljava/lang/String;
+	public abstract fun encodeRegistrationStart (Ljava/lang/Object;)Ljava/lang/String;
+}
+
 public final class dev/webauthn/network/KtorPasskeyRoutes {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V

--- a/client/webauthn-client-ktor/api/webauthn-client-ktor.klib.api
+++ b/client/webauthn-client-ktor/api/webauthn-client-ktor.klib.api
@@ -6,6 +6,25 @@
 // - Show declarations: true
 
 // Library unique name: <io.github.szijpeter:webauthn-client-ktor>
+abstract interface <#A: kotlin/Any?, #B: kotlin/Any?, #C: kotlin/Any?, #D: kotlin/Any?> dev.webauthn.network/KtorPasskeyContractCodec { // dev.webauthn.network/KtorPasskeyContractCodec|null[0]
+    abstract fun decodeAuthenticationFinish(kotlin/String): #D // dev.webauthn.network/KtorPasskeyContractCodec.decodeAuthenticationFinish|decodeAuthenticationFinish(kotlin.String){}[0]
+    abstract fun decodeAuthenticationStart(kotlin/String): dev.webauthn.model/ValidationResult<dev.webauthn.model/PublicKeyCredentialRequestOptions> // dev.webauthn.network/KtorPasskeyContractCodec.decodeAuthenticationStart|decodeAuthenticationStart(kotlin.String){}[0]
+    abstract fun decodeError(kotlin/String): kotlin/String? // dev.webauthn.network/KtorPasskeyContractCodec.decodeError|decodeError(kotlin.String){}[0]
+    abstract fun decodeRegistrationFinish(kotlin/String): #C // dev.webauthn.network/KtorPasskeyContractCodec.decodeRegistrationFinish|decodeRegistrationFinish(kotlin.String){}[0]
+    abstract fun decodeRegistrationStart(kotlin/String): dev.webauthn.model/ValidationResult<dev.webauthn.model/PublicKeyCredentialCreationOptions> // dev.webauthn.network/KtorPasskeyContractCodec.decodeRegistrationStart|decodeRegistrationStart(kotlin.String){}[0]
+    abstract fun encodeAuthenticationFinish(dev.webauthn.model/RawAuthenticationResponse): kotlin/String // dev.webauthn.network/KtorPasskeyContractCodec.encodeAuthenticationFinish|encodeAuthenticationFinish(dev.webauthn.model.RawAuthenticationResponse){}[0]
+    abstract fun encodeAuthenticationStart(#B): kotlin/String // dev.webauthn.network/KtorPasskeyContractCodec.encodeAuthenticationStart|encodeAuthenticationStart(1:1){}[0]
+    abstract fun encodeRegistrationFinish(dev.webauthn.model/RawRegistrationResponse): kotlin/String // dev.webauthn.network/KtorPasskeyContractCodec.encodeRegistrationFinish|encodeRegistrationFinish(dev.webauthn.model.RawRegistrationResponse){}[0]
+    abstract fun encodeRegistrationStart(#A): kotlin/String // dev.webauthn.network/KtorPasskeyContractCodec.encodeRegistrationStart|encodeRegistrationStart(1:0){}[0]
+}
+
+final class <#A: kotlin/Any?, #B: kotlin/Any?, #C: kotlin/Any?, #D: kotlin/Any?> dev.webauthn.network/KtorPasskeyBackend { // dev.webauthn.network/KtorPasskeyBackend|null[0]
+    constructor <init>(io.ktor.client/HttpClient, kotlin/String, dev.webauthn.network/KtorPasskeyContractCodec<#A, #B, #C, #D>, dev.webauthn.network/KtorPasskeyRoutes = ...) // dev.webauthn.network/KtorPasskeyBackend.<init>|<init>(io.ktor.client.HttpClient;kotlin.String;dev.webauthn.network.KtorPasskeyContractCodec<1:0,1:1,1:2,1:3>;dev.webauthn.network.KtorPasskeyRoutes){}[0]
+
+    final fun authenticationBackend(): dev.webauthn.client/AuthenticationBackend<#B, kotlin/Unit, #D> // dev.webauthn.network/KtorPasskeyBackend.authenticationBackend|authenticationBackend(){}[0]
+    final fun registrationBackend(): dev.webauthn.client/RegistrationBackend<#A, kotlin/Unit, #C> // dev.webauthn.network/KtorPasskeyBackend.registrationBackend|registrationBackend(){}[0]
+}
+
 final class dev.webauthn.network/AuthenticationStartPayload { // dev.webauthn.network/AuthenticationStartPayload|null[0]
     constructor <init>(kotlin/String, kotlin/String, kotlin/String? = ..., dev.webauthn.serialization/AuthenticationExtensionsClientInputsDto? = ...) // dev.webauthn.network/AuthenticationStartPayload.<init>|<init>(kotlin.String;kotlin.String;kotlin.String?;dev.webauthn.serialization.AuthenticationExtensionsClientInputsDto?){}[0]
 

--- a/client/webauthn-client-ktor/src/commonMain/kotlin/dev/webauthn/network/KtorPasskeyBackend.kt
+++ b/client/webauthn-client-ktor/src/commonMain/kotlin/dev/webauthn/network/KtorPasskeyBackend.kt
@@ -1,0 +1,129 @@
+package dev.webauthn.network
+
+import dev.webauthn.client.AuthenticationBackend
+import dev.webauthn.client.CeremonyStart
+import dev.webauthn.client.RegistrationBackend
+import dev.webauthn.model.PublicKeyCredentialCreationOptions
+import dev.webauthn.model.PublicKeyCredentialRequestOptions
+import dev.webauthn.model.RawAuthenticationResponse
+import dev.webauthn.model.RawRegistrationResponse
+import dev.webauthn.model.ValidationResult
+import io.ktor.client.HttpClient
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.isSuccess
+
+/**
+ * Codec-neutral Ktor transport that exposes typed [RegistrationBackend] and
+ * [AuthenticationBackend] instances.
+ */
+public class KtorPasskeyBackend<
+    RegistrationInput,
+    AuthenticationInput,
+    RegistrationOutput,
+    AuthenticationOutput,
+>(
+    private val httpClient: HttpClient,
+    endpointBase: String,
+    private val codec:
+        KtorPasskeyContractCodec<RegistrationInput, AuthenticationInput, RegistrationOutput, AuthenticationOutput>,
+    private val routes: KtorPasskeyRoutes = KtorPasskeyRoutes(),
+) {
+    private val endpointBase: String = endpointBase.trimEnd('/')
+
+    public fun registrationBackend(): RegistrationBackend<RegistrationInput, Unit, RegistrationOutput> =
+        object : RegistrationBackend<RegistrationInput, Unit, RegistrationOutput> {
+            override suspend fun start(
+                input: RegistrationInput,
+            ): CeremonyStart<Unit, PublicKeyCredentialCreationOptions> = CeremonyStart(
+                state = Unit,
+                options = postForOptions(
+                    path = routes.registerOptionsPath,
+                    payload = codec.encodeRegistrationStart(input),
+                    operation = "Registration start",
+                    decode = codec::decodeRegistrationStart,
+                ).toFlowValue(),
+            )
+
+            override suspend fun finish(state: Unit, response: RawRegistrationResponse): RegistrationOutput =
+                postForResult(
+                    path = routes.registerFinishPath,
+                    payload = codec.encodeRegistrationFinish(response),
+                    operation = "Registration finish",
+                    decode = codec::decodeRegistrationFinish,
+                )
+        }
+
+    public fun authenticationBackend(): AuthenticationBackend<AuthenticationInput, Unit, AuthenticationOutput> =
+        object : AuthenticationBackend<AuthenticationInput, Unit, AuthenticationOutput> {
+            override suspend fun start(
+                input: AuthenticationInput,
+            ): CeremonyStart<Unit, PublicKeyCredentialRequestOptions> = CeremonyStart(
+                state = Unit,
+                options = postForOptions(
+                    path = routes.signInOptionsPath,
+                    payload = codec.encodeAuthenticationStart(input),
+                    operation = "Authentication start",
+                    decode = codec::decodeAuthenticationStart,
+                ).toFlowValue(),
+            )
+
+            override suspend fun finish(state: Unit, response: RawAuthenticationResponse): AuthenticationOutput =
+                postForResult(
+                    path = routes.signInFinishPath,
+                    payload = codec.encodeAuthenticationFinish(response),
+                    operation = "Authentication finish",
+                    decode = codec::decodeAuthenticationFinish,
+                )
+        }
+
+    private fun endpointFor(path: String): String {
+        val normalizedPath = if (path.startsWith('/')) path else "/$path"
+        return "$endpointBase$normalizedPath"
+    }
+
+    private suspend fun <Output> postForOptions(
+        path: String,
+        payload: String,
+        operation: String,
+        decode: (String) -> ValidationResult<Output>,
+    ): ValidationResult<Output> = decode(post(path, payload, operation))
+
+    private suspend fun <Output> postForResult(
+        path: String,
+        payload: String,
+        operation: String,
+        decode: (String) -> Output,
+    ): Output = decode(post(path, payload, operation))
+
+    private suspend fun post(path: String, payload: String, operation: String): String {
+        val response = httpClient.post(endpointFor(path)) {
+            header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            setBody(payload)
+        }
+        val responseText = response.bodyAsText()
+        throwIfHttpError(response, responseText, operation, codec::decodeError)
+        return responseText
+    }
+}
+
+private fun <T> ValidationResult<T>.toFlowValue(): T = when (this) {
+    is ValidationResult.Valid -> value
+    is ValidationResult.Invalid -> throw IllegalArgumentException(errors.joinToString("; ") { it.message })
+}
+
+private fun throwIfHttpError(
+    response: HttpResponse,
+    responseText: String,
+    operation: String,
+    decodeError: (String) -> String?,
+) {
+    if (response.status.isSuccess()) return
+    val details = decodeError(responseText) ?: "<redacted non-empty body length=${responseText.length}>"
+    error("$operation failed with HTTP ${response.status.value}: $details")
+}

--- a/client/webauthn-client-ktor/src/commonMain/kotlin/dev/webauthn/network/KtorPasskeyContractCodec.kt
+++ b/client/webauthn-client-ktor/src/commonMain/kotlin/dev/webauthn/network/KtorPasskeyContractCodec.kt
@@ -1,0 +1,40 @@
+package dev.webauthn.network
+
+import dev.webauthn.model.PublicKeyCredentialCreationOptions
+import dev.webauthn.model.PublicKeyCredentialRequestOptions
+import dev.webauthn.model.RawAuthenticationResponse
+import dev.webauthn.model.RawRegistrationResponse
+import dev.webauthn.model.ValidationResult
+
+/**
+ * Serialization contract for a Ktor-backed passkey backend.
+ *
+ * The transport intentionally owns no JSON implementation. Applications that use the default
+ * `/webauthn/…` payloads can add the Kotlinx adapter artifact; alternate backend contracts can
+ * implement this interface without resolving Kotlinx serialization.
+ */
+public interface KtorPasskeyContractCodec<
+    RegistrationInput,
+    AuthenticationInput,
+    RegistrationOutput,
+    AuthenticationOutput,
+> {
+    public fun encodeRegistrationStart(input: RegistrationInput): String
+
+    public fun decodeRegistrationStart(value: String): ValidationResult<PublicKeyCredentialCreationOptions>
+
+    public fun encodeRegistrationFinish(response: RawRegistrationResponse): String
+
+    public fun decodeRegistrationFinish(value: String): RegistrationOutput
+
+    public fun encodeAuthenticationStart(input: AuthenticationInput): String
+
+    public fun decodeAuthenticationStart(value: String): ValidationResult<PublicKeyCredentialRequestOptions>
+
+    public fun encodeAuthenticationFinish(response: RawAuthenticationResponse): String
+
+    public fun decodeAuthenticationFinish(value: String): AuthenticationOutput
+
+    /** Returns a safe backend error message when available, otherwise `null`. */
+    public fun decodeError(value: String): String?
+}

--- a/docs/CLIENT_FIRST_EXECUTION.md
+++ b/docs/CLIENT_FIRST_EXECUTION.md
@@ -25,13 +25,18 @@ Example:
 
 <!-- doc-example: id=docs-client-first-execution-kotlin-1; owner=source; verify=compile; audience=consumer; source=documentation/examples/src/commonMain/kotlin/dev/webauthn/documentation/examples/NetworkClientExample.kt#network-client -->
 ```kotlin
-import dev.webauthn.network.KtorPasskeyServerClient
+import dev.webauthn.network.KtorPasskeyBackend
+import dev.webauthn.network.KtorPasskeyContractCodec
 import io.ktor.client.HttpClient
 
-fun serverClient(httpClient: HttpClient): KtorPasskeyServerClient {
-    return KtorPasskeyServerClient(
+fun <RegistrationInput, AuthenticationInput, RegistrationOutput, AuthenticationOutput> serverClient(
+    httpClient: HttpClient,
+    codec: KtorPasskeyContractCodec<RegistrationInput, AuthenticationInput, RegistrationOutput, AuthenticationOutput>,
+): KtorPasskeyBackend<RegistrationInput, AuthenticationInput, RegistrationOutput, AuthenticationOutput> {
+    return KtorPasskeyBackend(
         httpClient = httpClient,
         endpointBase = "https://example.com",
+        codec = codec,
     )
 }
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,7 +83,11 @@ no internal project dependencies without inventing an edge.
 
 `webauthn-client-core` owns the raw platform interaction boundary, while `webauthn-client-flow` owns optional
 start → prompt → finish orchestration. JSON, Android, iOS, Compose,
-PRF, and network modules build around that shared boundary. Platform bridges use
+PRF, and network modules build around that shared boundary. The codec-neutral
+`webauthn-client-ktor` typed backend receives its wire contract through
+`KtorPasskeyContractCodec`; `webauthn-client-ktor-kotlinx` is the optional
+default-contract implementation. The legacy Ktor client remains temporarily
+while consumers migrate. Platform bridges use
 the codec API only at their JSON boundary and return byte-preserving responses;
 protocol interpretation and ceremony validation remain server-side trust-boundary work.
 
@@ -95,7 +99,8 @@ flowchart TB
     PLATFORM["webauthn-client-platform<br/>(androidMain and iosMain)"]
     JSON["webauthn-client-json-core"]
     PRF["webauthn-client-prf-crypto<br/>(optional)"]
-    NETWORK["webauthn-client-ktor<br/>(optional)"]
+    NETWORK["webauthn-client-ktor<br/>(optional typed transport + legacy client)"]
+    NETWORK_KOTLINX["webauthn-client-ktor-kotlinx<br/>(optional default contract)"]
     CLIENT_CORE["webauthn-client-core"]
     CLIENT_FLOW["webauthn-client-flow<br/>(optional)"]
     JSON_API["webauthn-json-api"]
@@ -120,6 +125,8 @@ flowchart TB
 
     NETWORK --> CLIENT_CORE
     NETWORK --> FOUNDATION
+    NETWORK_KOTLINX --> NETWORK
+    NETWORK_KOTLINX --> JSON_API
 
     CLIENT_CORE --> FOUNDATION
     CLIENT_CORE --> MODEL
@@ -194,6 +201,7 @@ reusable library architecture.
 - `webauthn-client-core` owns shared client business logic and protocol interpretation; Android and iOS modules remain platform bridges that return raw output.
 - `webauthn-server-core-jvm` remains framework-agnostic; Ktor and Exposed are adapters.
 - `webauthn-crypto-api` stays vendor-neutral; implementations belong behind the crypto boundary.
+- `webauthn-client-ktor` accepts its backend wire format through `KtorPasskeyContractCodec`; the Kotlinx default contract lives in the optional `webauthn-client-ktor-kotlinx` companion artifact.
 - Optional adapters must not become hidden prerequisites of core modules.
 - Direct project dependencies shown here must be checked against the owning `build.gradle.kts` whenever the module graph changes.
 

--- a/documentation/example-inventory.md
+++ b/documentation/example-inventory.md
@@ -27,7 +27,7 @@ Managed blocks: **107**
 | readme-kotlin-2 | README.md:158 | Install | kotlin | consumer | configuration | documentation/consumer-smoke/client/build.gradle.kts.template#consumer-client-kmp-dependencies | consumer-compile |  |
 | readme-kotlin-3 | README.md:180 | Install | kotlin | consumer | configuration | documentation/consumer-smoke/server/build.gradle.kts.template#consumer-server-dependencies | consumer-compile |  |
 | readme-bash-1 | README.md:200 | Install | bash | maintainer | markdown | Markdown block | syntax |  |
-| readme-bash-2 | README.md:290 | Maintainer Workflow | bash | maintainer | markdown | Markdown block | syntax |  |
+| readme-bash-2 | README.md:291 | Maintainer Workflow | bash | maintainer | markdown | Markdown block | syntax |  |
 | client-webauthn-client-compose-readme-mermaid-1 | client/webauthn-client-compose/README.md:13 | What it provides | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
 | client-webauthn-client-compose-readme-kotlin-1 | client/webauthn-client-compose/README.md:34 | How to use | kotlin | consumer | source | documentation/examples/src/platformMain/kotlin/dev/webauthn/documentation/examples/ComposeClientExample.kt#compose-client | platform-compile |  |
 | client-webauthn-client-core-readme-mermaid-1 | client/webauthn-client-flow/README.md:12 | What it provides | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
@@ -35,8 +35,8 @@ Managed blocks: **107**
 | client-webauthn-client-core-readme-kotlin-2 | client/webauthn-client-flow/README.md:94 | Capabilities API | kotlin | consumer | source | documentation/examples/src/commonMain/kotlin/dev/webauthn/documentation/examples/ClientCapabilitiesExample.kt#client-capabilities | compile |  |
 | client-webauthn-client-json-core-readme-kotlin-1 | client/webauthn-client-json-core/README.md:18 | How to use | kotlin | consumer | source | documentation/examples/src/commonMain/kotlin/dev/webauthn/documentation/examples/JsonClientExample.kt#json-client | compile |  |
 | client-webauthn-client-json-core-readme-mermaid-1 | client/webauthn-client-json-core/README.md:34 | How it fits | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
-| client-webauthn-client-ktor-readme-kotlin-1 | client/webauthn-client-ktor/README.md:22 | How to use | kotlin | consumer | source | documentation/examples/src/commonMain/kotlin/dev/webauthn/documentation/examples/NetworkClientExample.kt#network-client | compile |  |
-| client-webauthn-client-ktor-readme-mermaid-1 | client/webauthn-client-ktor/README.md:39 | How it fits | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
+| client-webauthn-client-ktor-readme-kotlin-1 | client/webauthn-client-ktor/README.md:27 | How to use | kotlin | consumer | source | documentation/examples/src/commonMain/kotlin/dev/webauthn/documentation/examples/NetworkClientExample.kt#network-client | compile |  |
+| client-webauthn-client-ktor-readme-mermaid-1 | client/webauthn-client-ktor/README.md:49 | How it fits | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
 | client-webauthn-client-platform-readme-kotlin-1 | client/webauthn-client-platform/README.md:23 | Android | kotlin | consumer | source | documentation/examples/src/androidMain/kotlin/dev/webauthn/documentation/examples/AndroidClientExample.kt#android-client | platform-compile |  |
 | client-webauthn-client-platform-readme-kotlin-2 | client/webauthn-client-platform/README.md:38 | iOS | kotlin | consumer | source | documentation/examples/src/iosMain/kotlin/dev/webauthn/documentation/examples/IosClientExample.kt#ios-client | platform-compile |  |
 | client-webauthn-client-platform-readme-mermaid-1 | client/webauthn-client-platform/README.md:51 | How it fits | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
@@ -57,9 +57,9 @@ Managed blocks: **107**
 | core-webauthn-protocol-readme-mermaid-1 | core/webauthn-protocol/README.md:33 | How it fits in the system | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
 | core-webauthn-runtime-core-readme-kotlin-1 | core/webauthn-runtime-core/README.md:28 | How to use | kotlin | consumer | source | documentation/examples/src/commonMain/kotlin/dev/webauthn/documentation/examples/RuntimeExample.kt#runtime-cancellation | unit |  |
 | docs-client-first-execution-kotlin-1 | docs/CLIENT_FIRST_EXECUTION.md:27 | Option A: First-party default backend contract | kotlin | consumer | source | documentation/examples/src/commonMain/kotlin/dev/webauthn/documentation/examples/NetworkClientExample.kt#network-client | compile |  |
-| docs-client-first-execution-bash-1 | docs/CLIENT_FIRST_EXECUTION.md:63 | Local Backend App (`sample/backend-ktor`) | bash | consumer | markdown | Markdown block | syntax |  |
-| docs-client-first-execution-bash-2 | docs/CLIENT_FIRST_EXECUTION.md:70 | Local Backend App (`sample/backend-ktor`) | bash | consumer | markdown | Markdown block | syntax |  |
-| docs-client-first-execution-kotlin-2 | docs/CLIENT_FIRST_EXECUTION.md:107 | `webauthn-client-json-core` (optional) | kotlin | consumer | source | documentation/examples/src/androidMain/kotlin/dev/webauthn/documentation/examples/AndroidJsonClientExample.kt#android-json-client | platform-compile |  |
+| docs-client-first-execution-bash-1 | docs/CLIENT_FIRST_EXECUTION.md:68 | Local Backend App (`sample/backend-ktor`) | bash | consumer | markdown | Markdown block | syntax |  |
+| docs-client-first-execution-bash-2 | docs/CLIENT_FIRST_EXECUTION.md:75 | Local Backend App (`sample/backend-ktor`) | bash | consumer | markdown | Markdown block | syntax |  |
+| docs-client-first-execution-kotlin-2 | docs/CLIENT_FIRST_EXECUTION.md:112 | `webauthn-client-json-core` (optional) | kotlin | consumer | source | documentation/examples/src/androidMain/kotlin/dev/webauthn/documentation/examples/AndroidJsonClientExample.kt#android-json-client | platform-compile |  |
 | docs-maven-central-bash-1 | docs/MAVEN_CENTRAL.md:68 | Local Validation | bash | contributor | markdown | Markdown block | syntax |  |
 | docs-ai-workflows-bash-1 | docs/ai/WORKFLOWS.md:10 | Standard Change Workflow | bash | contributor | markdown | Markdown block | syntax |  |
 | docs-ai-workflows-bash-2 | docs/ai/WORKFLOWS.md:17 | Standard Change Workflow | bash | contributor | markdown | Markdown block | syntax |  |
@@ -74,8 +74,8 @@ Managed blocks: **107**
 | docs-ai-workflows-bash-11 | docs/ai/WORKFLOWS.md:101 | Release-Prep Workflow | bash | contributor | markdown | Markdown block | syntax |  |
 | docs-architecture-mermaid-1 | docs/architecture.md:32 | Reference integration | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
 | docs-architecture-mermaid-2 | docs/architecture.md:58 | Shared foundation | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
-| docs-architecture-mermaid-3 | docs/architecture.md:91 | Client stack | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
-| docs-architecture-mermaid-4 | docs/architecture.md:148 | JVM server stack | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
+| docs-architecture-mermaid-3 | docs/architecture.md:95 | Client stack | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
+| docs-architecture-mermaid-4 | docs/architecture.md:155 | JVM server stack | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
 | docs-unused-return-value-checker-bash-1 | docs/unused-return-value-checker.md:20 | Audit coverage | bash | contributor | markdown | Markdown block | syntax |  |
 | docs-wiki-quality-and-release-bash-1 | docs/wiki/quality-and-release.md:12 | Default Quality Gates | bash | contributor | markdown | Markdown block | syntax |  |
 | platform-bom-readme-kotlin-1 | platform/bom/README.md:25 | How to use | kotlin | consumer | configuration | documentation/consumer-smoke/server/build.gradle.kts.template#consumer-server-dependencies | consumer-compile |  |

--- a/documentation/examples/src/commonMain/kotlin/dev/webauthn/documentation/examples/NetworkClientExample.kt
+++ b/documentation/examples/src/commonMain/kotlin/dev/webauthn/documentation/examples/NetworkClientExample.kt
@@ -1,13 +1,18 @@
 package dev.webauthn.documentation.examples
 
 // docs-region network-client
-import dev.webauthn.network.KtorPasskeyServerClient
+import dev.webauthn.network.KtorPasskeyBackend
+import dev.webauthn.network.KtorPasskeyContractCodec
 import io.ktor.client.HttpClient
 
-fun serverClient(httpClient: HttpClient): KtorPasskeyServerClient {
-    return KtorPasskeyServerClient(
+fun <RegistrationInput, AuthenticationInput, RegistrationOutput, AuthenticationOutput> serverClient(
+    httpClient: HttpClient,
+    codec: KtorPasskeyContractCodec<RegistrationInput, AuthenticationInput, RegistrationOutput, AuthenticationOutput>,
+): KtorPasskeyBackend<RegistrationInput, AuthenticationInput, RegistrationOutput, AuthenticationOutput> {
+    return KtorPasskeyBackend(
         httpClient = httpClient,
         endpointBase = "https://example.com",
+        codec = codec,
     )
 }
 // docs-endregion network-client

--- a/platform/bom/build.gradle.kts
+++ b/platform/bom/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
         api("${project.group}:webauthn-client-compose:${project.version}")
         api("${project.group}:webauthn-client-platform:${project.version}")
         api("${project.group}:webauthn-client-ktor:${project.version}")
+        api("${project.group}:webauthn-client-ktor-kotlinx:${project.version}")
         api("${project.group}:webauthn-attestation-mds:${project.version}")
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -44,6 +44,7 @@ include(
     ":client:webauthn-client-compose",
     ":client:webauthn-client-platform",
     ":client:webauthn-client-ktor",
+    ":client:webauthn-client-ktor-kotlinx",
     ":sample:backend-ktor",
     ":sample:android-passkey",
     ":sample:ios-passkey",


### PR DESCRIPTION
## Summary

- Add a codec-neutral `KtorPasskeyBackend` and `KtorPasskeyContractCodec` for typed flow backends.
- Add the opt-in `webauthn-client-ktor-kotlinx` artifact with the default Kotlinx contract, API baselines, BOM entry, and codec coverage.
- Document the migration path; the legacy `KtorPasskeyServerClient` remains temporarily for downstream consumer migration.

## Verification

- `./gradlew :client:webauthn-client-ktor-kotlinx:allTests --stacktrace --console=plain`
- `tools/agent/quality-gate.sh --mode strict --scope changed --block false`
- `./gradlew apiCheck docsCheck publishToMavenLocal --stacktrace --console=plain`