### PR TITLE
refactor(sample): use typed passkey flow

### DIFF
--- a/sample/compose-passkey/README.md
+++ b/sample/compose-passkey/README.md
@@ -121,11 +121,8 @@ The auth screen is intentionally the cleanest API example in the repo:
 
 <!-- doc-example: id=sample-compose-passkey-readme-kotlin-1; owner=sample; verify=sample-build; audience=consumer; source=sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/screens/auth/AuthRoute.kt#compose-sample-auth-route -->
 ```kotlin
-    val controller = rememberPasskeyController(
-        serverClient = serverClient,
-        passkeyClient = passkeyClient,
-    )
-    val controllerState by controller.uiState.collectAsState()
+    val flow = rememberPasskeyFlow(passkeyClient)
+    var controllerState by remember { mutableStateOf<PasskeyControllerState>(PasskeyControllerState.Idle) }
     val canRegister by coordinator.canRegister.collectAsState()
     val actionsEnabled = areCeremonyActionsEnabled(controllerState)
 ```

--- a/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/app/App.kt
+++ b/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/app/App.kt
@@ -5,9 +5,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import dev.webauthn.client.compose.rememberPasskeyClient
 import dev.webauthn.network.KtorPasskeyServerClient
+import dev.webauthn.network.kotlinx.KotlinxKtorPasskeyBackend
 import dev.webauthn.samples.composepasskey.app.di.sampleAppModules
 import dev.webauthn.samples.composepasskey.data.logging.DebugLogStore
 import dev.webauthn.samples.composepasskey.data.network.DemoPasskeyServerClient
+import dev.webauthn.samples.composepasskey.data.network.DemoPasskeyBackend
 import dev.webauthn.samples.composepasskey.data.network.normalizedEndpoint
 import dev.webauthn.samples.composepasskey.data.network.rememberPlatformHttpClient
 import dev.webauthn.samples.composepasskey.domain.passkey.PasskeyDemoConfig
@@ -32,13 +34,20 @@ fun App() {
             endpointBase = config.endpointBase.normalizedEndpoint(),
         )
     }
+    val backend: DemoPasskeyBackend = remember(httpClient, config.endpointBase) {
+        KotlinxKtorPasskeyBackend(
+            httpClient = httpClient,
+            endpointBase = config.endpointBase.normalizedEndpoint(),
+        )
+    }
 
-    val modules = remember(config, debugLogs, passkeyClient, serverClient) {
+    val modules = remember(config, debugLogs, passkeyClient, serverClient, backend) {
         sampleAppModules(
             config = config,
             debugLogs = debugLogs,
             passkeyClient = passkeyClient,
             serverClient = serverClient,
+            backend = backend,
         )
     }
     val koinConfig = remember(modules) {

--- a/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/app/di/SampleAppModules.kt
+++ b/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/app/di/SampleAppModules.kt
@@ -4,6 +4,7 @@ import dev.webauthn.client.PasskeyClient
 import dev.webauthn.samples.composepasskey.app.navigation.AppRoute
 import dev.webauthn.samples.composepasskey.data.logging.DebugLogStore
 import dev.webauthn.samples.composepasskey.data.network.DemoPasskeyServerClient
+import dev.webauthn.samples.composepasskey.data.network.DemoPasskeyBackend
 import dev.webauthn.samples.composepasskey.data.session.AppSessionStore
 import dev.webauthn.samples.composepasskey.domain.passkey.PasskeyDemoConfig
 import dev.webauthn.samples.composepasskey.domain.prf.InMemoryPrfSaltStore
@@ -23,6 +24,7 @@ internal fun sampleAppModules(
     debugLogs: DebugLogStore,
     passkeyClient: PasskeyClient,
     serverClient: DemoPasskeyServerClient,
+    backend: DemoPasskeyBackend,
 ): List<Module> {
     return listOf(
         module {
@@ -30,6 +32,7 @@ internal fun sampleAppModules(
             single<DebugLogStore> { debugLogs }
             single<PasskeyClient> { passkeyClient }
             single<DemoPasskeyServerClient> { serverClient }
+            single<DemoPasskeyBackend> { backend }
             single<AppSessionStore> { AppSessionStore() }
             single<PrfSaltStore> { InMemoryPrfSaltStore() }
 

--- a/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/data/network/DemoPasskeyServerClient.kt
+++ b/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/data/network/DemoPasskeyServerClient.kt
@@ -3,6 +3,9 @@ package dev.webauthn.samples.composepasskey.data.network
 import dev.webauthn.client.PasskeyServerClient
 import dev.webauthn.network.AuthenticationStartPayload
 import dev.webauthn.network.RegistrationStartPayload
+import dev.webauthn.network.kotlinx.KotlinxKtorPasskeyBackend
 
 internal typealias DemoPasskeyServerClient =
     PasskeyServerClient<RegistrationStartPayload, AuthenticationStartPayload>
+
+internal typealias DemoPasskeyBackend = KotlinxKtorPasskeyBackend

--- a/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/screens/auth/AuthRoute.kt
+++ b/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/screens/auth/AuthRoute.kt
@@ -4,14 +4,22 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import dev.webauthn.client.CeremonyFailure
+import dev.webauthn.client.CeremonyResult
+import dev.webauthn.client.PasskeyAction
 import dev.webauthn.client.PasskeyClient
-import dev.webauthn.client.compose.rememberPasskeyController
+import dev.webauthn.client.PasskeyClientError
+import dev.webauthn.client.PasskeyControllerState
+import dev.webauthn.client.PasskeyFinishResult
+import dev.webauthn.client.compose.rememberPasskeyFlow
 import dev.webauthn.samples.composepasskey.app.LocalShowDebugLogs
 import dev.webauthn.samples.composepasskey.app.auth.AuthDemoCoordinator
 import dev.webauthn.samples.composepasskey.data.logging.DebugLogStore
-import dev.webauthn.samples.composepasskey.data.network.DemoPasskeyServerClient
+import dev.webauthn.samples.composepasskey.data.network.DemoPasskeyBackend
 import dev.webauthn.samples.composepasskey.data.session.AppSessionStore
 import dev.webauthn.samples.composepasskey.domain.passkey.PasskeyDemoConfig
 import dev.webauthn.samples.composepasskey.domain.passkey.areCeremonyActionsEnabled
@@ -28,7 +36,7 @@ internal fun AuthRoute() {
     val debugLogs: DebugLogStore = koinInject()
     val sessionStore: AppSessionStore = koinInject()
     val passkeyClient: PasskeyClient = koinInject()
-    val serverClient: DemoPasskeyServerClient = koinInject()
+    val backend: DemoPasskeyBackend = koinInject()
     val scope = rememberCoroutineScope()
     val coordinator = remember(config, debugLogs, sessionStore) {
         AuthDemoCoordinator(
@@ -38,11 +46,8 @@ internal fun AuthRoute() {
         )
     }
     // docs-region compose-sample-auth-route
-    val controller = rememberPasskeyController(
-        serverClient = serverClient,
-        passkeyClient = passkeyClient,
-    )
-    val controllerState by controller.uiState.collectAsState()
+    val flow = rememberPasskeyFlow(passkeyClient)
+    var controllerState by remember { mutableStateOf<PasskeyControllerState>(PasskeyControllerState.Idle) }
     val canRegister by coordinator.canRegister.collectAsState()
     val actionsEnabled = areCeremonyActionsEnabled(controllerState)
     // docs-endregion compose-sample-auth-route
@@ -60,7 +65,13 @@ internal fun AuthRoute() {
             if (actionsEnabled && canRegister) {
                 coordinator.onRegisterClicked()
                 scope.launch {
-                    controller.register(config.toRegistrationStartPayload())
+                    controllerState = flow.register(
+                        input = config.toRegistrationStartPayload(),
+                        backend = backend.registrationBackend(),
+                        onPhaseChanged = { phase ->
+                            controllerState = PasskeyControllerState.InProgress(PasskeyAction.REGISTER, phase)
+                        },
+                    ).toDemoControllerState(PasskeyAction.REGISTER)
                 }
             }
         },
@@ -68,9 +79,37 @@ internal fun AuthRoute() {
             if (actionsEnabled) {
                 coordinator.onSignInClicked()
                 scope.launch {
-                    controller.signIn(config.toAuthenticationStartPayload())
+                    controllerState = flow.signIn(
+                        input = config.toAuthenticationStartPayload(),
+                        backend = backend.authenticationBackend(),
+                        onPhaseChanged = { phase ->
+                            controllerState = PasskeyControllerState.InProgress(PasskeyAction.SIGN_IN, phase)
+                        },
+                    ).toDemoControllerState(PasskeyAction.SIGN_IN)
                 }
             }
+        },
+    )
+}
+
+internal fun CeremonyResult<PasskeyFinishResult>.toDemoControllerState(
+    action: PasskeyAction,
+): PasskeyControllerState = when (this) {
+    is CeremonyResult.Success -> when (val result = value) {
+        PasskeyFinishResult.Verified -> PasskeyControllerState.Success(action)
+        is PasskeyFinishResult.Rejected -> PasskeyControllerState.Failure(
+            action = action,
+            error = PasskeyClientError.Transport(result.message ?: "The server rejected the passkey response."),
+        )
+    }
+
+    is CeremonyResult.Failure -> PasskeyControllerState.Failure(
+        action = action,
+        error = when (val failure = error) {
+            CeremonyFailure.AlreadyInProgress ->
+                PasskeyClientError.Transport("A passkey ceremony is already in progress.")
+            is CeremonyFailure.Backend -> PasskeyClientError.Transport(failure.message)
+            is CeremonyFailure.Platform -> failure.error
         },
     )
 }

--- a/sample/compose-passkey/src/commonTest/kotlin/dev/webauthn/samples/composepasskey/AuthDemoCoordinatorTest.kt
+++ b/sample/compose-passkey/src/commonTest/kotlin/dev/webauthn/samples/composepasskey/AuthDemoCoordinatorTest.kt
@@ -1,19 +1,40 @@
 package dev.webauthn.samples.composepasskey
 
 import dev.webauthn.client.PasskeyAction
+import dev.webauthn.client.CeremonyFailure
+import dev.webauthn.client.CeremonyResult
+import dev.webauthn.client.PasskeyClientError
 import dev.webauthn.client.PasskeyControllerState
+import dev.webauthn.client.PasskeyFinishResult
 import dev.webauthn.client.PasskeyPhase
 import dev.webauthn.samples.composepasskey.app.auth.AuthDemoCoordinator
 import dev.webauthn.samples.composepasskey.data.logging.DebugLogStore
 import dev.webauthn.samples.composepasskey.data.session.AppSessionState
 import dev.webauthn.samples.composepasskey.data.session.AppSessionStore
 import dev.webauthn.samples.composepasskey.domain.passkey.PasskeyDemoConfig
+import dev.webauthn.samples.composepasskey.ui.screens.auth.toDemoControllerState
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class AuthDemoCoordinatorTest {
+    @Test
+    fun typed_flow_results_map_to_caller_owned_ui_state() {
+        assertEquals(
+            PasskeyControllerState.Success(PasskeyAction.REGISTER),
+            CeremonyResult.Success(PasskeyFinishResult.Verified).toDemoControllerState(PasskeyAction.REGISTER),
+        )
+
+        val failure = assertIs<PasskeyControllerState.Failure>(
+            CeremonyResult.Failure(CeremonyFailure.Backend("offline"))
+                .toDemoControllerState(PasskeyAction.SIGN_IN),
+        )
+        assertEquals(PasskeyAction.SIGN_IN, failure.action)
+        assertEquals(PasskeyClientError.Transport("offline"), failure.error)
+    }
+
     @Test
     fun register_success_disables_register_after_logging_action_and_transition() {
         val debugLogs = DebugLogStore()


### PR DESCRIPTION
## Summary

- Run the Compose sample registration and sign-in paths through `rememberPasskeyFlow` and `KotlinxKtorPasskeyBackend`.
- Keep Compose state in the sample while mapping typed flow results to the existing display state and coordinator.
- Retain the legacy Ktor client only for the separate PRF sample path, and add result-mapping coverage.

## Verification

- `./gradlew :sample:compose-passkey:allTests --stacktrace --console=plain`
- `tools/agent/quality-gate.sh --mode strict --scope changed --block false`
- `./gradlew docsCheck --stacktrace --console=plain`