### PR TITLE
refactor(cli): use typed ceremony backends

### DIFF
--- a/docs/DESKTOP_CLI_STRATEGY.md
+++ b/docs/DESKTOP_CLI_STRATEGY.md
@@ -33,7 +33,7 @@ For this POC, we also validate a no-browser native CLI path to understand practi
 ## 4. CLI Strategy For This Repository
 
 1. Keep CLI as a separate deployable sample module (`:sample:passkey-cli`), not an additional JVM target inside an existing KMP module.
-2. Reuse existing typed contracts for backend orchestration (`KtorPasskeyServerClient`).
+2. Reuse the typed backend contracts via `KotlinxKtorPasskeyBackend`.
 3. Keep native authenticator interaction behind a narrow adapter boundary:
 - `AuthenticatorAdapter`
 - `PythonFido2Adapter`

--- a/sample/passkey-cli/build.gradle.kts
+++ b/sample/passkey-cli/build.gradle.kts
@@ -13,8 +13,6 @@ dependencies {
     implementation(project(":client:webauthn-client-ktor-kotlinx"))
     implementation(project(":core:webauthn-runtime-core"))
     implementation(libs.ktor.client.cio)
-    implementation(libs.ktor.client.content.negotiation)
-    implementation(libs.ktor.serialization.kotlinx.json)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.serialization.json)
 

--- a/sample/passkey-cli/src/main/kotlin/dev/webauthn/samples/passkeycli/CliApplication.kt
+++ b/sample/passkey-cli/src/main/kotlin/dev/webauthn/samples/passkeycli/CliApplication.kt
@@ -1,11 +1,8 @@
 package dev.webauthn.samples.passkeycli
 
-import dev.webauthn.network.KtorPasskeyServerClient
+import dev.webauthn.network.kotlinx.KotlinxKtorPasskeyBackend
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.serialization.kotlinx.json.json
-import kotlinx.serialization.json.Json
 
 internal class CliApplication(
     private val parser: CliParser = CliParser(),
@@ -40,7 +37,7 @@ internal class CliApplication(
     private suspend fun runCeremony(invocation: CliInvocation.Ceremony): Int {
         val httpClient = createHttpClient()
         return try {
-            val serverClient = KtorPasskeyServerClient(
+            val backend = KotlinxKtorPasskeyBackend(
                 httpClient = httpClient,
                 endpointBase = invocation.common.endpointBase,
             )
@@ -57,7 +54,8 @@ internal class CliApplication(
             }
             val runner = PasskeyCeremonyRunner(
                 authenticatorAdapter = adapter,
-                serverClient = serverClient,
+                registrationBackend = backend.registrationBackend(),
+                authenticationBackend = backend.authenticationBackend(),
                 stdout = stdout,
                 stderr = stderr,
             )
@@ -70,17 +68,7 @@ internal class CliApplication(
         }
     }
 
-    private fun createHttpClient(): HttpClient {
-        return HttpClient(CIO) {
-            install(ContentNegotiation) {
-                json(
-                    Json {
-                        ignoreUnknownKeys = true
-                    },
-                )
-            }
-        }
-    }
+    private fun createHttpClient(): HttpClient = HttpClient(CIO)
 }
 
 internal const val EXIT_PARSE_USAGE: Int = 64

--- a/sample/passkey-cli/src/main/kotlin/dev/webauthn/samples/passkeycli/PasskeyCeremonyRunner.kt
+++ b/sample/passkey-cli/src/main/kotlin/dev/webauthn/samples/passkeycli/PasskeyCeremonyRunner.kt
@@ -1,7 +1,8 @@
 package dev.webauthn.samples.passkeycli
 
+import dev.webauthn.client.AuthenticationBackend
 import dev.webauthn.client.PasskeyFinishResult
-import dev.webauthn.client.PasskeyServerClient
+import dev.webauthn.client.RegistrationBackend
 import dev.webauthn.model.RawAuthenticationResponse
 import dev.webauthn.model.PublicKeyCredentialCreationOptions
 import dev.webauthn.model.PublicKeyCredentialRequestOptions
@@ -14,7 +15,8 @@ import dev.webauthn.serialization.WebAuthnDtoMapper
 
 internal class PasskeyCeremonyRunner(
     private val authenticatorAdapter: AuthenticatorAdapter,
-    private val serverClient: PasskeyServerClient<RegistrationStartPayload, AuthenticationStartPayload>,
+    private val registrationBackend: RegistrationBackend<RegistrationStartPayload, Unit, PasskeyFinishResult>,
+    private val authenticationBackend: AuthenticationBackend<AuthenticationStartPayload, Unit, PasskeyFinishResult>,
     private val stdout: Appendable = System.out,
     private val stderr: Appendable = System.err,
 ) {
@@ -29,9 +31,9 @@ internal class PasskeyCeremonyRunner(
             userHandle = command.userHandle,
         )
 
-        val options = resolveRegisterOptions(startPayload) ?: return EXIT_OPTIONS_FAILURE
+        val options = startRegistration(startPayload) ?: return EXIT_OPTIONS_FAILURE
         val response = resolveRegistrationResponse(command.common.origin, options) ?: return EXIT_ADAPTER_FAILURE
-        return finishRegistration(startPayload, options, response)
+        return finishRegistration(response)
     }
 
     suspend fun runAuthenticate(command: CliInvocation.Authenticate): Int {
@@ -41,43 +43,29 @@ internal class PasskeyCeremonyRunner(
             userName = command.userName,
         )
 
-        val options = resolveAuthenticationOptions(startPayload) ?: return EXIT_OPTIONS_FAILURE
+        val options = startAuthentication(startPayload) ?: return EXIT_OPTIONS_FAILURE
         val response = resolveAuthenticationResponse(command.common.origin, options) ?: return EXIT_ADAPTER_FAILURE
-        return finishAuthentication(startPayload, options, response)
+        return finishAuthentication(response)
     }
 
-    private suspend fun resolveRegisterOptions(
+    private suspend fun startRegistration(
         payload: RegistrationStartPayload,
     ): PublicKeyCredentialCreationOptions? {
-        val result = runSuspendCatching { serverClient.getRegisterOptions(payload) }
+        return runSuspendCatching { registrationBackend.start(payload).options }
             .getOrElse { error ->
                 stderr.appendLine("Failed to fetch registration options: ${error.displayMessage()}")
-                return null
-            }
-        return when (result) {
-            is ValidationResult.Valid -> result.value
-            is ValidationResult.Invalid -> {
-                stderr.appendLine("Registration options failed validation: ${result.formatErrors()}")
                 null
             }
-        }
     }
 
-    private suspend fun resolveAuthenticationOptions(
+    private suspend fun startAuthentication(
         payload: AuthenticationStartPayload,
     ): PublicKeyCredentialRequestOptions? {
-        val result = runSuspendCatching { serverClient.getSignInOptions(payload) }
+        return runSuspendCatching { authenticationBackend.start(payload).options }
             .getOrElse { error ->
                 stderr.appendLine("Failed to fetch authentication options: ${error.displayMessage()}")
-                return null
-            }
-        return when (result) {
-            is ValidationResult.Valid -> result.value
-            is ValidationResult.Invalid -> {
-                stderr.appendLine("Authentication options failed validation: ${result.formatErrors()}")
                 null
             }
-        }
     }
 
     private suspend fun resolveRegistrationResponse(
@@ -119,17 +107,10 @@ internal class PasskeyCeremonyRunner(
     }
 
     private suspend fun finishRegistration(
-        payload: RegistrationStartPayload,
-        options: PublicKeyCredentialCreationOptions,
         response: RawRegistrationResponse,
     ): Int {
-        val challenge = options.challenge.value.encoded()
         val finish = runSuspendCatching {
-            serverClient.finishRegister(
-                params = payload,
-                response = response,
-                challengeAsBase64Url = challenge,
-            )
+            registrationBackend.finish(state = Unit, response = response)
         }.getOrElse { error ->
             stderr.appendLine("Registration finish call failed: ${error.displayMessage()}")
             return EXIT_FINISH_FAILURE
@@ -148,17 +129,10 @@ internal class PasskeyCeremonyRunner(
     }
 
     private suspend fun finishAuthentication(
-        payload: AuthenticationStartPayload,
-        options: PublicKeyCredentialRequestOptions,
         response: RawAuthenticationResponse,
     ): Int {
-        val challenge = options.challenge.value.encoded()
         val finish = runSuspendCatching {
-            serverClient.finishSignIn(
-                params = payload,
-                response = response,
-                challengeAsBase64Url = challenge,
-            )
+            authenticationBackend.finish(state = Unit, response = response)
         }.getOrElse { error ->
             stderr.appendLine("Authentication finish call failed: ${error.displayMessage()}")
             return EXIT_FINISH_FAILURE

--- a/sample/passkey-cli/src/test/kotlin/dev/webauthn/samples/passkeycli/PasskeyCeremonyRunnerTest.kt
+++ b/sample/passkey-cli/src/test/kotlin/dev/webauthn/samples/passkeycli/PasskeyCeremonyRunnerTest.kt
@@ -1,7 +1,9 @@
 package dev.webauthn.samples.passkeycli
 
+import dev.webauthn.client.AuthenticationBackend
+import dev.webauthn.client.CeremonyStart
 import dev.webauthn.client.PasskeyFinishResult
-import dev.webauthn.client.PasskeyServerClient
+import dev.webauthn.client.RegistrationBackend
 import dev.webauthn.model.Challenge
 import dev.webauthn.model.PublicKeyCredentialCreationOptions
 import dev.webauthn.model.PublicKeyCredentialParameters
@@ -30,8 +32,8 @@ import kotlin.test.assertTrue
 
 class PasskeyCeremonyRunnerTest {
     @Test
-    fun register_happyPath_finishesWithOriginalChallenge() = runTest {
-        val serverClient = FakeServerClient(
+    fun register_happyPath_finishesThroughTypedBackend() = runTest {
+        val backends = FakeServerBackends(
             registerOptions = ValidationResult.Valid(validRegisterOptions()),
             authOptions = ValidationResult.Valid(validAuthenticationOptions()),
             finishRegisterResult = PasskeyFinishResult.Verified,
@@ -45,7 +47,8 @@ class PasskeyCeremonyRunnerTest {
         val stderr = StringBuilder()
         val runner = PasskeyCeremonyRunner(
             authenticatorAdapter = adapter,
-            serverClient = serverClient,
+            registrationBackend = backends.registrationBackend,
+            authenticationBackend = backends.authenticationBackend,
             stdout = stdout,
             stderr = stderr,
         )
@@ -60,7 +63,7 @@ class PasskeyCeremonyRunnerTest {
         )
 
         assertEquals(0, exitCode)
-        assertEquals(validRegisterOptions().challenge.value.encoded(), serverClient.lastRegisterChallenge)
+        assertEquals(1, backends.registrationFinishCalls)
         assertTrue(stdout.toString().contains("Registration verified"))
         assertTrue(stderr.isEmpty())
     }
@@ -70,7 +73,7 @@ class PasskeyCeremonyRunnerTest {
         val invalidAuthResponse = validAuthenticationResponseDto().copy(
             response = validAuthenticationResponseDto().response.copy(signature = "not-base64url"),
         )
-        val serverClient = FakeServerClient(
+        val backends = FakeServerBackends(
             registerOptions = ValidationResult.Valid(validRegisterOptions()),
             authOptions = ValidationResult.Valid(validAuthenticationOptions()),
             finishRegisterResult = PasskeyFinishResult.Verified,
@@ -84,7 +87,8 @@ class PasskeyCeremonyRunnerTest {
         val stderr = StringBuilder()
         val runner = PasskeyCeremonyRunner(
             authenticatorAdapter = adapter,
-            serverClient = serverClient,
+            registrationBackend = backends.registrationBackend,
+            authenticationBackend = backends.authenticationBackend,
             stdout = stdout,
             stderr = stderr,
         )
@@ -103,7 +107,7 @@ class PasskeyCeremonyRunnerTest {
 
     @Test
     fun register_rejectedWithoutMessage_usesSafeFallbackText() = runTest {
-        val serverClient = FakeServerClient(
+        val backends = FakeServerBackends(
             registerOptions = ValidationResult.Valid(validRegisterOptions()),
             authOptions = ValidationResult.Valid(validAuthenticationOptions()),
             finishRegisterResult = PasskeyFinishResult.Rejected(),
@@ -117,7 +121,8 @@ class PasskeyCeremonyRunnerTest {
         val stderr = StringBuilder()
         val runner = PasskeyCeremonyRunner(
             authenticatorAdapter = adapter,
-            serverClient = serverClient,
+            registrationBackend = backends.registrationBackend,
+            authenticationBackend = backends.authenticationBackend,
             stdout = stdout,
             stderr = stderr,
         )
@@ -144,7 +149,8 @@ class PasskeyCeremonyRunnerTest {
         )
         val runner = PasskeyCeremonyRunner(
             authenticatorAdapter = adapter,
-            serverClient = CancellationServerClient(),
+            registrationBackend = CancellationRegistrationBackend(),
+            authenticationBackend = UnusedAuthenticationBackend(),
             stdout = StringBuilder(),
             stderr = StringBuilder(),
         )
@@ -177,65 +183,69 @@ private class FakeAuthenticatorAdapter(
     ): AuthenticationResponseDto = authenticationResponse
 }
 
-private class FakeServerClient(
+private class FakeServerBackends(
     private val registerOptions: ValidationResult<PublicKeyCredentialCreationOptions>,
     private val authOptions: ValidationResult<PublicKeyCredentialRequestOptions>,
     private val finishRegisterResult: PasskeyFinishResult,
     private val finishSignInResult: PasskeyFinishResult,
-) : PasskeyServerClient<RegistrationStartPayload, AuthenticationStartPayload> {
-    var lastRegisterChallenge: String? = null
+) {
+    var registrationFinishCalls: Int = 0
 
-    override suspend fun getRegisterOptions(
-        params: RegistrationStartPayload,
-    ): ValidationResult<PublicKeyCredentialCreationOptions> = registerOptions
+    val registrationBackend = object : RegistrationBackend<RegistrationStartPayload, Unit, PasskeyFinishResult> {
+        override suspend fun start(
+            input: RegistrationStartPayload,
+        ): CeremonyStart<Unit, PublicKeyCredentialCreationOptions> = CeremonyStart(
+            state = Unit,
+            options = registerOptions.orThrow("registration"),
+        )
 
-    override suspend fun finishRegister(
-        params: RegistrationStartPayload,
-        response: RawRegistrationResponse,
-        challengeAsBase64Url: String,
-    ): PasskeyFinishResult {
-        lastRegisterChallenge = challengeAsBase64Url
-        return finishRegisterResult
+        override suspend fun finish(state: Unit, response: RawRegistrationResponse): PasskeyFinishResult {
+            registrationFinishCalls += 1
+            return finishRegisterResult
+        }
     }
 
-    override suspend fun getSignInOptions(
-        params: AuthenticationStartPayload,
-    ): ValidationResult<PublicKeyCredentialRequestOptions> = authOptions
+    val authenticationBackend = object : AuthenticationBackend<AuthenticationStartPayload, Unit, PasskeyFinishResult> {
+        override suspend fun start(
+            input: AuthenticationStartPayload,
+        ): CeremonyStart<Unit, PublicKeyCredentialRequestOptions> = CeremonyStart(
+            state = Unit,
+            options = authOptions.orThrow("authentication"),
+        )
 
-    override suspend fun finishSignIn(
-        params: AuthenticationStartPayload,
-        response: RawAuthenticationResponse,
-        challengeAsBase64Url: String,
-    ): PasskeyFinishResult = finishSignInResult
+        override suspend fun finish(state: Unit, response: RawAuthenticationResponse): PasskeyFinishResult =
+            finishSignInResult
+    }
 }
 
-private class CancellationServerClient :
-    PasskeyServerClient<RegistrationStartPayload, AuthenticationStartPayload> {
-    override suspend fun getRegisterOptions(
-        params: RegistrationStartPayload,
-    ): ValidationResult<PublicKeyCredentialCreationOptions> {
+private class CancellationRegistrationBackend :
+    RegistrationBackend<RegistrationStartPayload, Unit, PasskeyFinishResult> {
+    override suspend fun start(
+        input: RegistrationStartPayload,
+    ): CeremonyStart<Unit, PublicKeyCredentialCreationOptions> {
         throw CancellationException("simulated cancellation")
     }
 
-    override suspend fun finishRegister(
-        params: RegistrationStartPayload,
-        response: RawRegistrationResponse,
-        challengeAsBase64Url: String,
-    ): PasskeyFinishResult = PasskeyFinishResult.Verified
+    override suspend fun finish(state: Unit, response: RawRegistrationResponse): PasskeyFinishResult =
+        PasskeyFinishResult.Verified
+}
 
-    override suspend fun getSignInOptions(
-        params: AuthenticationStartPayload,
-    ): ValidationResult<PublicKeyCredentialRequestOptions> {
+private class UnusedAuthenticationBackend :
+    AuthenticationBackend<AuthenticationStartPayload, Unit, PasskeyFinishResult> {
+    override suspend fun start(
+        input: AuthenticationStartPayload,
+    ): CeremonyStart<Unit, PublicKeyCredentialRequestOptions> {
         throw UnsupportedOperationException("not used")
     }
 
-    override suspend fun finishSignIn(
-        params: AuthenticationStartPayload,
-        response: RawAuthenticationResponse,
-        challengeAsBase64Url: String,
-    ): PasskeyFinishResult {
+    override suspend fun finish(state: Unit, response: RawAuthenticationResponse): PasskeyFinishResult {
         throw UnsupportedOperationException("not used")
     }
+}
+
+private fun <T> ValidationResult<T>.orThrow(operation: String): T = when (this) {
+    is ValidationResult.Valid -> value
+    is ValidationResult.Invalid -> error("$operation options are invalid")
 }
 
 private fun validRegisterOptions(): PublicKeyCredentialCreationOptions {


### PR DESCRIPTION
## Summary

- Replace the CLI `PasskeyServerClient` path with typed registration and authentication backends.
- Use `KotlinxKtorPasskeyBackend` for the default contract and remove the CLI Ktor content-negotiation setup.
- Preserve CLI error/exit behavior with typed-backend test doubles and verify the finish path directly.

## Verification

- `./gradlew :sample:passkey-cli:test --stacktrace --console=plain`
- `tools/agent/quality-gate.sh --mode strict --scope changed --block false`