### PR TITLE
refactor(sample): use typed backend for PRF

### DIFF
--- a/sample/compose-passkey/READINESS_CHECKLIST.md
+++ b/sample/compose-passkey/READINESS_CHECKLIST.md
@@ -20,7 +20,7 @@ Pass condition:
 
 - all commands succeed without test failures.
 - shared sample tests cover sealed-state lifecycle outcomes for register/sign-in plus debug-log transition behavior.
-- runtime platform client wiring is provided by `webauthn-client-compose` (`rememberPasskeyClient()` + `rememberPasskeyController()`), and the auth route remains the clearest reference usage.
+- runtime platform client wiring is provided by `webauthn-client-compose` (`rememberPasskeyClient()` + `rememberPasskeyFlow()`), and the auth route remains the clearest reference usage.
 - Android UI smoke test sources compile in CI (`:sample:compose-passkey-android:compileDebugAndroidTestKotlin`).
 
 ## 2. Local sample backend

--- a/sample/compose-passkey/README.md
+++ b/sample/compose-passkey/README.md
@@ -8,8 +8,8 @@ Compose Multiplatform sample app for a minimal passkey E2E flow against `sample/
 2. End-to-end passkey registration against `POST /webauthn/registration/start` + `/webauthn/registration/finish`.
 3. End-to-end passkey sign-in against `POST /webauthn/authentication/start` + `/webauthn/authentication/finish`.
 4. Two-screen auth/session flow: `Auth` screen (`Register`, `Sign In`) and signed-in extension demo screen with local logout transition back to `Auth`.
-5. Compose-first auth wiring via `rememberPasskeyController(...)`, with `PasskeyControllerState` driving UI status and action enablement.
-6. Direct sample wiring to `KtorPasskeyServerClient` against the default backend contract.
+5. Compose-first auth wiring via `rememberPasskeyFlow(...)`, with caller-owned UI state driving status and action enablement.
+6. Direct sample wiring to `KotlinxKtorPasskeyBackend` against the default backend contract.
 7. PRF crypto demo flow: caller-owned salt load/generation, `Sign In + PRF`, session key derivation, AES-GCM encrypt/decrypt, and explicit session clear.
 8. Explicit `Logs` action in the shared header opening an in-app debug log sheet (wall-clock timestamps, level, source, message).
 9. Structured ceremony + network logs emitted with tag `PasskeyDemo`.
@@ -148,9 +148,9 @@ Preview limitations and constraints:
 
 ## Test layering (fake vs real client)
 
-- `sample:compose-passkey` `commonTest` validates flow behavior with `FakePasskeyClient` and `FakeServerClient` (`PasskeyServerClient`) so orchestration is deterministic across KMP targets.
-- Runtime client wiring uses `webauthn-client-compose` (`rememberPasskeyClient()` + `rememberPasskeyController()`).
-- Runtime server wiring uses `webauthn-client-ktor` (`KtorPasskeyServerClient`).
+- `sample:compose-passkey` `commonTest` validates typed backend behavior with `FakePasskeyClient` and typed backend doubles so orchestration is deterministic across KMP targets.
+- Runtime client wiring uses `webauthn-client-compose` (`rememberPasskeyClient()` + `rememberPasskeyFlow()`).
+- Runtime server wiring uses `webauthn-client-ktor-kotlinx` (`KotlinxKtorPasskeyBackend`).
 - Final readiness still requires the live register/sign-in checklist run on a real/emulated Android device with provider dependencies present.
 
 ## Android provider prerequisite

--- a/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/app/App.kt
+++ b/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/app/App.kt
@@ -4,11 +4,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import dev.webauthn.client.compose.rememberPasskeyClient
-import dev.webauthn.network.KtorPasskeyServerClient
 import dev.webauthn.network.kotlinx.KotlinxKtorPasskeyBackend
 import dev.webauthn.samples.composepasskey.app.di.sampleAppModules
 import dev.webauthn.samples.composepasskey.data.logging.DebugLogStore
-import dev.webauthn.samples.composepasskey.data.network.DemoPasskeyServerClient
 import dev.webauthn.samples.composepasskey.data.network.DemoPasskeyBackend
 import dev.webauthn.samples.composepasskey.data.network.normalizedEndpoint
 import dev.webauthn.samples.composepasskey.data.network.rememberPlatformHttpClient
@@ -28,12 +26,6 @@ fun App() {
     val httpClient = rememberPlatformHttpClient(onLogLine = httpLogSink)
     val config = remember { PasskeyDemoConfig() }
     val passkeyClient = rememberPasskeyClient()
-    val serverClient: DemoPasskeyServerClient = remember(httpClient, config.endpointBase) {
-        KtorPasskeyServerClient(
-            httpClient = httpClient,
-            endpointBase = config.endpointBase.normalizedEndpoint(),
-        )
-    }
     val backend: DemoPasskeyBackend = remember(httpClient, config.endpointBase) {
         KotlinxKtorPasskeyBackend(
             httpClient = httpClient,
@@ -41,12 +33,11 @@ fun App() {
         )
     }
 
-    val modules = remember(config, debugLogs, passkeyClient, serverClient, backend) {
+    val modules = remember(config, debugLogs, passkeyClient, backend) {
         sampleAppModules(
             config = config,
             debugLogs = debugLogs,
             passkeyClient = passkeyClient,
-            serverClient = serverClient,
             backend = backend,
         )
     }

--- a/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/app/di/SampleAppModules.kt
+++ b/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/app/di/SampleAppModules.kt
@@ -3,7 +3,6 @@ package dev.webauthn.samples.composepasskey.app.di
 import dev.webauthn.client.PasskeyClient
 import dev.webauthn.samples.composepasskey.app.navigation.AppRoute
 import dev.webauthn.samples.composepasskey.data.logging.DebugLogStore
-import dev.webauthn.samples.composepasskey.data.network.DemoPasskeyServerClient
 import dev.webauthn.samples.composepasskey.data.network.DemoPasskeyBackend
 import dev.webauthn.samples.composepasskey.data.session.AppSessionStore
 import dev.webauthn.samples.composepasskey.domain.passkey.PasskeyDemoConfig
@@ -23,7 +22,6 @@ internal fun sampleAppModules(
     config: PasskeyDemoConfig,
     debugLogs: DebugLogStore,
     passkeyClient: PasskeyClient,
-    serverClient: DemoPasskeyServerClient,
     backend: DemoPasskeyBackend,
 ): List<Module> {
     return listOf(
@@ -31,7 +29,6 @@ internal fun sampleAppModules(
             single<PasskeyDemoConfig> { config }
             single<DebugLogStore> { debugLogs }
             single<PasskeyClient> { passkeyClient }
-            single<DemoPasskeyServerClient> { serverClient }
             single<DemoPasskeyBackend> { backend }
             single<AppSessionStore> { AppSessionStore() }
             single<PrfSaltStore> { InMemoryPrfSaltStore() }
@@ -43,7 +40,7 @@ internal fun sampleAppModules(
                     sessionStore = get(),
                     saltStore = get(),
                     passkeyClient = get(),
-                    serverClient = get(),
+                    backend = get(),
                 )
             }
 

--- a/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/data/network/DemoPasskeyServerClient.kt
+++ b/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/data/network/DemoPasskeyServerClient.kt
@@ -1,11 +1,5 @@
 package dev.webauthn.samples.composepasskey.data.network
 
-import dev.webauthn.client.PasskeyServerClient
-import dev.webauthn.network.AuthenticationStartPayload
-import dev.webauthn.network.RegistrationStartPayload
 import dev.webauthn.network.kotlinx.KotlinxKtorPasskeyBackend
-
-internal typealias DemoPasskeyServerClient =
-    PasskeyServerClient<RegistrationStartPayload, AuthenticationStartPayload>
 
 internal typealias DemoPasskeyBackend = KotlinxKtorPasskeyBackend

--- a/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/domain/prf/PrfCryptoDemo.kt
+++ b/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/domain/prf/PrfCryptoDemo.kt
@@ -1,5 +1,6 @@
 package dev.webauthn.samples.composepasskey.domain.prf
 
+import dev.webauthn.client.AuthenticationBackend
 import dev.webauthn.client.PasskeyClient
 import dev.webauthn.client.PasskeyFinishResult
 import dev.webauthn.client.PasskeyResult
@@ -9,9 +10,8 @@ import dev.webauthn.client.prf.PrfCryptoSession
 import dev.webauthn.model.AuthenticationExtensionsPRFValues
 import dev.webauthn.model.Base64UrlBytes
 import dev.webauthn.model.ExperimentalWebAuthnL3Api
-import dev.webauthn.model.ValidationResult
+import dev.webauthn.network.AuthenticationStartPayload
 import dev.webauthn.runtime.runSuspendCatching
-import dev.webauthn.samples.composepasskey.data.network.DemoPasskeyServerClient
 import dev.webauthn.samples.composepasskey.domain.passkey.PasskeyDemoConfig
 import dev.webauthn.samples.composepasskey.domain.passkey.toAuthenticationStartPayload
 import kotlin.random.Random
@@ -54,7 +54,7 @@ internal class InMemoryPrfSaltStore : PrfSaltStore {
 @OptIn(ExperimentalWebAuthnL3Api::class)
 internal class PrfCryptoDemoController(
     passkeyClient: PasskeyClient,
-    private val serverClient: DemoPasskeyServerClient,
+    private val serverClient: AuthenticationBackend<AuthenticationStartPayload, Unit, PasskeyFinishResult>,
     private val saltStore: PrfSaltStore,
 ) {
     private val prfCryptoClient: PrfCryptoClient = PrfCryptoClient(passkeyClient)
@@ -71,21 +71,14 @@ internal class PrfCryptoDemoController(
         val saltScope = "${config.rpId}:${config.userHandle}"
         val firstSalt = saltStore.loadOrCreate(saltScope)
         val startPayload = config.toAuthenticationStartPayload(prfSalt = firstSalt)
-        val startResult = runSuspendCatching {
-            serverClient.getSignInOptions(startPayload)
+        val ceremonyStart = runSuspendCatching {
+            serverClient.start(startPayload)
         }.getOrElse { throwable ->
             return PrfDemoResult.Failure(
                 "PRF sign-in start failed: ${throwable.message ?: "unknown error"}",
             )
         }
-        val signInOptions = when (startResult) {
-            is ValidationResult.Invalid -> {
-                val details = startResult.errors.joinToString("; ") { "${it.field}: ${it.message}" }
-                return PrfDemoResult.Failure("PRF sign-in start failed: $details")
-            }
-
-            is ValidationResult.Valid -> startResult.value
-        }
+        val signInOptions = ceremonyStart.options
         val authResult = when (
             val assertionResult = prfCryptoClient.authenticateWithPrf(
                 options = signInOptions,
@@ -102,11 +95,7 @@ internal class PrfCryptoDemoController(
         var sessionTransferred = false
         try {
             val finishResult = runSuspendCatching {
-                serverClient.finishSignIn(
-                    params = startPayload,
-                    response = authResult.response,
-                    challengeAsBase64Url = signInOptions.challenge.value.encoded(),
-                )
+                serverClient.finish(state = ceremonyStart.state, response = authResult.response)
             }.getOrElse { throwable ->
                 return PrfDemoResult.Failure(
                     "PRF sign-in finish failed: ${throwable.message ?: "unknown error"}",

--- a/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/screens/main/MainViewModel.kt
+++ b/sample/compose-passkey/src/commonMain/kotlin/dev/webauthn/samples/composepasskey/ui/screens/main/MainViewModel.kt
@@ -8,7 +8,7 @@ import dev.webauthn.client.PasskeyClient
 import dev.webauthn.model.WebAuthnExtension
 import dev.webauthn.runtime.runSuspendCatching
 import dev.webauthn.samples.composepasskey.data.logging.DebugLogStore
-import dev.webauthn.samples.composepasskey.data.network.DemoPasskeyServerClient
+import dev.webauthn.samples.composepasskey.data.network.DemoPasskeyBackend
 import dev.webauthn.samples.composepasskey.data.session.AppSessionState
 import dev.webauthn.samples.composepasskey.data.session.AppSessionStore
 import dev.webauthn.samples.composepasskey.domain.passkey.PasskeyDemoConfig
@@ -27,7 +27,7 @@ internal class MainViewModel(
     private val sessionStore: AppSessionStore,
     private val saltStore: PrfSaltStore,
     passkeyClient: PasskeyClient,
-    serverClient: DemoPasskeyServerClient,
+    backend: DemoPasskeyBackend,
 ) : ViewModel() {
     val uiState: StateFlow<MainUiState> field =
         MutableStateFlow<MainUiState>(MainUiState(userName = config.userName))
@@ -35,7 +35,7 @@ internal class MainViewModel(
     private val prfCapability = PasskeyCapability.Extension(WebAuthnExtension.Prf)
     private val prfDemoController = PrfCryptoDemoController(
         passkeyClient = passkeyClient,
-        serverClient = serverClient,
+        serverClient = backend.authenticationBackend(),
         saltStore = saltStore,
     )
 

--- a/sample/compose-passkey/src/commonTest/kotlin/dev/webauthn/samples/composepasskey/PrfCryptoDemoControllerTest.kt
+++ b/sample/compose-passkey/src/commonTest/kotlin/dev/webauthn/samples/composepasskey/PrfCryptoDemoControllerTest.kt
@@ -2,10 +2,11 @@
 
 package dev.webauthn.samples.composepasskey
 
+import dev.webauthn.client.AuthenticationBackend
+import dev.webauthn.client.CeremonyStart
 import dev.webauthn.client.PasskeyClient
 import dev.webauthn.client.PasskeyFinishResult
 import dev.webauthn.client.PasskeyResult
-import dev.webauthn.client.PasskeyServerClient
 import dev.webauthn.model.AuthenticationExtensionsClientOutputs
 import dev.webauthn.model.AuthenticationExtensionsPRFValues
 import dev.webauthn.model.RawAuthenticationResponse
@@ -20,7 +21,6 @@ import dev.webauthn.model.RawRegistrationResponse
 import dev.webauthn.model.RpId
 import dev.webauthn.model.ValidationResult
 import dev.webauthn.network.AuthenticationStartPayload
-import dev.webauthn.network.RegistrationStartPayload
 import dev.webauthn.samples.composepasskey.domain.passkey.PasskeyDemoConfig
 import dev.webauthn.samples.composepasskey.domain.prf.PrfCryptoDemoController
 import dev.webauthn.samples.composepasskey.domain.prf.PrfCryptoDemoSessionState
@@ -288,34 +288,24 @@ private class PrfTestServerClient(
     private val signInVerifyResult: Boolean = true,
     private val startThrowable: Throwable? = null,
     private val finishThrowable: Throwable? = null,
-) : PasskeyServerClient<RegistrationStartPayload, AuthenticationStartPayload> {
+) : AuthenticationBackend<AuthenticationStartPayload, Unit, PasskeyFinishResult> {
     var signInStartCalls: Int = 0
     var lastAuthenticationStartPayload: AuthenticationStartPayload? = null
 
-    override suspend fun getRegisterOptions(params: RegistrationStartPayload): ValidationResult<PublicKeyCredentialCreationOptions> {
-        error("not used")
-    }
-
-    override suspend fun finishRegister(
-        params: RegistrationStartPayload,
-        response: RawRegistrationResponse,
-        challengeAsBase64Url: String,
-    ): PasskeyFinishResult {
-        error("not used")
-    }
-
-    override suspend fun getSignInOptions(params: AuthenticationStartPayload): ValidationResult<PublicKeyCredentialRequestOptions> {
+    override suspend fun start(
+        input: AuthenticationStartPayload,
+    ): CeremonyStart<Unit, PublicKeyCredentialRequestOptions> {
         startThrowable?.let { throw it }
         signInStartCalls += 1
-        lastAuthenticationStartPayload = params
-        return signInOptions
+        lastAuthenticationStartPayload = input
+        val options = when (signInOptions) {
+            is ValidationResult.Valid -> signInOptions.value
+            is ValidationResult.Invalid -> error("authentication options are invalid")
+        }
+        return CeremonyStart(state = Unit, options = options)
     }
 
-    override suspend fun finishSignIn(
-        params: AuthenticationStartPayload,
-        response: RawAuthenticationResponse,
-        challengeAsBase64Url: String,
-    ): PasskeyFinishResult {
+    override suspend fun finish(state: Unit, response: RawAuthenticationResponse): PasskeyFinishResult {
         finishThrowable?.let { throw it }
         return if (signInVerifyResult) {
             PasskeyFinishResult.Verified


### PR DESCRIPTION
## Summary

- Move the Compose sample PRF sign-in path from `PasskeyServerClient` to the typed authentication backend.
- Remove runtime construction and DI registration of `KtorPasskeyServerClient`; one `KotlinxKtorPasskeyBackend` now serves all sample ceremonies.
- Update PRF doubles and reference docs to retain deterministic KMP coverage.

## Verification

- `./gradlew :sample:compose-passkey:allTests --stacktrace --console=plain`
- `tools/agent/quality-gate.sh --mode strict --scope changed --block false`