### PR TITLE
chore(release): prepare 0.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
         run: |
           chmod +x tools/agent/*.sh .githooks/pre-commit .githooks/pre-push
           tools/agent/verify-harness-sync.sh
+      - name: Verify release note extraction
+        run: bash tools/agent/extract-release-notes-test.sh
 
   detekt:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,18 +17,23 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: publish-maven-central
+  cancel-in-progress: false
 
 jobs:
   publish:
     if: github.ref == 'refs/heads/main'
-    concurrency:
-      group: publish-maven-central
-      cancel-in-progress: false
+    outputs:
+      resolved_version: ${{ steps.resolve_version.outputs.resolved_version }}
     runs-on: macos-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
@@ -67,6 +72,16 @@ jobs:
             exit 1
           fi
 
+      - name: Validate curated release notes
+        if: ${{ inputs.release_mode == 'publish-and-release' }}
+        env:
+          RELEASE_VERSION: ${{ steps.resolve_version.outputs.resolved_version }}
+        run: |
+          bash tools/agent/extract-release-notes.sh \
+            "$RELEASE_VERSION" \
+            CHANGELOG.md \
+            "$RUNNER_TEMP/release-notes.md"
+
       - name: Publish to Maven Central
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
@@ -88,11 +103,29 @@ jobs:
             ./gradlew publishToMavenCentral --no-daemon ${VERSION_ARG:+"$VERSION_ARG"}
           fi
 
+  github-release:
+    if: ${{ inputs.release_mode == 'publish-and-release' }}
+    needs: [publish]
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Extract curated release notes
+        env:
+          RELEASE_VERSION: ${{ needs.publish.outputs.resolved_version }}
+        run: |
+          bash tools/agent/extract-release-notes.sh \
+            "$RELEASE_VERSION" \
+            CHANGELOG.md \
+            "$RUNNER_TEMP/release-notes.md"
       - name: Create GitHub release
-        if: ${{ inputs.release_mode == 'publish-and-release' }}
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: v${{ steps.resolve_version.outputs.resolved_version }}
+          RELEASE_TAG: v${{ needs.publish.outputs.resolved_version }}
         run: |
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
             echo "Release $RELEASE_TAG already exists; skipping."
@@ -102,4 +135,4 @@ jobs:
           gh release create "$RELEASE_TAG" \
             --target "$GITHUB_SHA" \
             --title "$RELEASE_TAG" \
-            --generate-notes
+            --notes-file "$RUNNER_TEMP/release-notes.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,44 @@ The format is based on Keep a Changelog and this project follows coordinated pre
 
 ## Unreleased
 
+## 0.4.0 - 2026-08-23
+
+### Added
+
+- Codec-neutral `webauthn-json-api` and binary `webauthn-protocol` artifacts, plus byte-preserving `RawRegistrationResponse` and `RawAuthenticationResponse` models for untrusted platform/transport data.
+- Generic `PasskeyFlow` orchestration with typed registration/authentication backends, opaque continuation state, application-defined finish output, explicit concurrent-use failure, and application-owned presentation state.
+- Replaceable client composition artifacts: `webauthn-client-ktor`, opt-in `webauthn-client-ktor-kotlinx`, `webauthn-client-defaults`, and the source-set-first `webauthn-client-platform` bridge for Android and iOS.
+- Username-optional authentication start for discoverable-credential sign-in.
+- Compiled documentation examples, dependency-purity consumer checks, WebAuthn compliance cross-checks, an experimental desktop passkey CLI, and configurable PR change-profile automation.
+
 ### Changed
 
-- **BREAKING**: client ceremonies now use raw platform responses and the generic `PasskeyFlow` with opaque backend state and application-defined finish output. Replace the removed controller/server-client APIs with `PasskeyFlow`, `RegistrationBackend`, and `AuthenticationBackend`.
-- **BREAKING**: JSON and Ktor transport seams are implementation-neutral. Depend on `webauthn-json-api`/`webauthn-client-ktor` and provide a codec; add `webauthn-json-kotlinx` or `webauthn-client-ktor-kotlinx` only when choosing the Kotlinx defaults.
-- **BREAKING**: `webauthn-client-android` and `webauthn-client-ios` are replaced by the source-set-first `webauthn-client-platform`; use `webauthn-client-defaults` for recommended platform construction.
-- **BREAKING**: `webauthn-network-ktor-client` is replaced by `webauthn-client-ktor-kotlinx` for the default contract or `webauthn-client-ktor` plus an application codec for custom contracts.
-- Server finish requests now derive signed client data from the raw credential response, preventing separately supplied challenge, origin, or type values from bypassing the trust boundary.
+- **BREAKING**: `PasskeyClient` now returns raw platform responses, and ceremonies use `PasskeyFlow`, `RegistrationBackend`, and `AuthenticationBackend`. Replace the removed controller/server-client APIs and keep UI state in the application. See the [client-first migration map](https://github.com/szijpeter/webauthn-kotlin-multiplatform/blob/v0.4.0/docs/CLIENT_FIRST_EXECUTION.md).
+- **BREAKING**: `RegistrationFinishRequest` and `AuthenticationFinishRequest` now accept only the raw credential response. Custom server adapters must supply a neutral collected-client-data decoder; callers can no longer provide separate challenge, origin, or ceremony-type claims.
+- **BREAKING**: JSON and Ktor seams are implementation-neutral. Supply a `WebAuthnJsonCodec` and, for custom HTTP contracts, a `KtorPasskeyContractCodec`; add the Kotlinx artifacts only when selecting the repository defaults.
+- **BREAKING**: capability reporting is now tri-state: `PasskeyCapabilities.support` maps typed `PasskeyCapability` values to `CapabilitySupport`. Replace `supported`, `platformVersionHints`, `supports(String)`, and `PlatformFeature` with `supportOf`/`supports` and `PasskeyCapability.Platform(PlatformCapability)`.
+- **BREAKING**: `PasskeyClientError.Platform` no longer retains a `Throwable`, and the low-level `Transport` error is removed; backend and HTTP failures belong to the flow/contract layers.
+- **BREAKING**: `webauthn-serialization-kotlinx` is replaced by `webauthn-json-kotlinx`; `webauthn-client-android` and `webauthn-client-ios` are replaced by `webauthn-client-platform`; and `webauthn-network-ktor-client` is replaced by `webauthn-client-ktor-kotlinx` or `webauthn-client-ktor` with an application codec.
+- **BREAKING**: `iosX64` artifacts are no longer published because upstream cryptography dependencies removed Apple X64 support. Supported Apple targets are `iosArm64` and `iosSimulatorArm64`.
+- Project modules now use `core/`, `client/`, `server/`, and `sample/` source-set-oriented directories without changing retained Maven coordinates.
+- Security-critical validation, parsing, conversion, cryptography, and trust APIs are marked for Kotlin's unused-return-value checker; repository builds treat ignored marked results as errors.
+- The build baseline now uses Kotlin 2.4.10, Gradle 9.7, Android Gradle Plugin 9.3.1/compile SDK 37, Ktor 3.5.2, Signum 0.16.0, and Signum Indispensable 3.26.0.
+
+### Fixed
+
+- Platform prompt ownership and Android rotation handling now keep activity-bound UI context explicit and avoid retaining stale hosts.
+- Flow failures no longer misclassify application callbacks or unexpected platform exceptions as backend failures; backend and callback exceptions follow the application's own policy.
+- Codec-neutral Ktor backends preserve caller-defined continuation state from start through finish instead of assuming server-side `Unit` state.
+- Public protocol return values retain immutable byte-value types rather than exposing mutable `ByteArray` results.
+
+### Removed
+
+- Legacy `PasskeyController`, `PasskeyServerClient`, `PasskeyFinishResult`, controller-owned Compose state, and the old Ktor server client.
+- Published artifacts `webauthn-client-android`, `webauthn-client-ios`, `webauthn-network-ktor-client`, and `webauthn-serialization-kotlinx`. Use the replacements listed above.
+
+### Security
+
+- Server finish processing now derives challenge, origin, and ceremony type exclusively from signed `clientDataJSON` in the raw credential response. Regression coverage rejects mismatched claims and replaying an old response against a fresh ceremony.
 
 ## 0.3.0 - 2026-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ The format is based on Keep a Changelog and this project follows coordinated pre
 
 ### Security
 
-- Server finish processing now derives challenge, origin, and ceremony type exclusively from signed `clientDataJSON` in the raw credential response. Regression coverage rejects mismatched claims and replaying an old response against a fresh ceremony.
+- Server finish processing now derives challenge, origin, and ceremony type exclusively from the exact raw `clientDataJSON` bytes in the credential response. Authentication verifies `authenticatorData || SHA-256(clientDataJSON)` against the assertion signature, and signed registration attestation formats hash those same bytes during verification; `none` attestation remains unsigned. Regression coverage rejects mismatched claims and replaying an old response against a fresh ceremony.
 
 ## 0.3.0 - 2026-03-31
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,4 +40,4 @@ When reporting, include affected module(s), threat model assumptions, and whethe
 - Renovate manages dependency and GitHub Actions updates.
 - The sample backend defaults to strict attestation verification; use `WEBAUTHN_SAMPLE_ATTESTATION=NONE` only as an explicit local-development override.
 - Maven Central publication is a manual workflow and requires signing plus Central Portal credentials.
-- The publish workflow uses `contents:write` only for `publish-and-release` to create the matching GitHub release tag.
+- The Central publishing job runs with read-only repository contents and disables persisted Git credentials before executing Gradle. A separate `publish-and-release`-only job receives `contents:write` solely to create the matching GitHub release tag from curated changelog notes.

--- a/docs/MAVEN_CENTRAL.md
+++ b/docs/MAVEN_CENTRAL.md
@@ -21,6 +21,8 @@ Published:
 
 - `webauthn-cbor-core`
 - `webauthn-model`
+- `webauthn-json-api`
+- `webauthn-protocol`
 - `webauthn-runtime-core`
 - `webauthn-json-kotlinx`
 - `webauthn-core`
@@ -73,6 +75,8 @@ tools/agent/quality-gate.sh --mode strict --scope full --block true
 bash tools/agent/check-published-consumer-smoke.sh
 ```
 
+If the workstation intentionally has no release signing key, `publishToMavenLocal` may be repeated with `-PsignAllPublications=false` after confirming that the only failure was a missing signatory. This validates publication metadata and consumer resolution but does not replace the live workflow's mandatory signed publication.
+
 ## Workflow
 
 Use [`.github/workflows/publish.yml`](../.github/workflows/publish.yml).
@@ -86,7 +90,8 @@ Inputs:
 Guardrails:
 
 - `publish-and-release` is blocked for snapshot versions.
-- `publish-and-release` creates the matching GitHub release tag (`vX.Y.Z`) after successful Central publication.
+- `publish-and-release` requires a matching versioned `CHANGELOG.md` section and creates the GitHub release/tag (`vX.Y.Z`) from those curated notes after successful Central publication.
+- The Central job has read-only repository contents and no persisted Git credentials; only the separate GitHub-release job receives `contents:write`.
 - Publishing remains manual; merges to `main` do not auto-publish.
 
 ## Release Runbook

--- a/docs/PUBLIC_LAUNCH_CHECKLIST.md
+++ b/docs/PUBLIC_LAUNCH_CHECKLIST.md
@@ -7,7 +7,7 @@ Use this checklist when moving from private to public operation.
 1. Security policy file exists and is current: `SECURITY.md`.
 2. CI workflows use least-privilege `permissions`, explicit versioned action references, and
    `persist-credentials: false` on every checkout before repository code executes.
-   - `Publish` workflow requires `contents:write` only to create the release tag in `publish-and-release` mode.
+   - Central publication runs with read-only repository contents and no persisted Git credentials; a separate `publish-and-release`-only job requires `contents:write` solely to create the release tag from curated changelog notes.
    - Any privileged `pull_request_target` workflow checks out executable code and configuration only from the trusted default branch, never a pull request head, and treats pull request content as API metadata only.
 3. Dependency automation exists and is current: `.github/renovate.json`.
 4. Local/sensitive files are ignored (`.env*`, `local.properties`, build outputs, IDE state).

--- a/docs/ai/RELEASE_0_4_0_PLAN.md
+++ b/docs/ai/RELEASE_0_4_0_PLAN.md
@@ -7,7 +7,7 @@ Status: release candidate preparation in progress; publication requires explicit
 - Latest official GitHub and Maven Central release: `v0.3.0` / `0.3.0`.
 - Target release: `0.4.0`, a coordinated minor release across the complete published artifact surface.
 - Release-prep base: `origin/main` at `476871db5eeb018ec8ae22a78622cdec17e6e060`; the final release SHA will be the merged release-prep commit after its current-head CI succeeds.
-- Included: all commits on `main` since `v0.3.0`, including the signed-client-data security fix, raw/protocol/JSON foundation, server trust-boundary correction, final client/platform/flow/Ktor/default composition, dependency upgrades, documentation verification, and PR change-profile automation.
+- Included: all commits on `main` since `v0.3.0`, including the single-authoritative-client-data security fix, raw/protocol/JSON foundation, server trust-boundary correction, final client/platform/flow/Ktor/default composition, dependency upgrades, documentation verification, and PR change-profile automation.
 - Excluded unless merged and this plan/changelog are refreshed before publication: open PRs #170, #172, #171, and draft #202.
 
 ## Readiness Evidence

--- a/docs/ai/RELEASE_0_4_0_PLAN.md
+++ b/docs/ai/RELEASE_0_4_0_PLAN.md
@@ -1,0 +1,60 @@
+# 0.4.0 Release Execution Map
+
+Status: release candidate preparation in progress; publication requires explicit maintainer approval.
+
+## Scope
+
+- Latest official GitHub and Maven Central release: `v0.3.0` / `0.3.0`.
+- Target release: `0.4.0`, a coordinated minor release across the complete published artifact surface.
+- Release-prep base: `origin/main` at `476871db5eeb018ec8ae22a78622cdec17e6e060`; the final release SHA will be the merged release-prep commit after its current-head CI succeeds.
+- Included: all commits on `main` since `v0.3.0`, including the signed-client-data security fix, raw/protocol/JSON foundation, server trust-boundary correction, final client/platform/flow/Ktor/default composition, dependency upgrades, documentation verification, and PR change-profile automation.
+- Excluded unless merged and this plan/changelog are refreshed before publication: open PRs #170, #172, #171, and draft #202.
+
+## Readiness Evidence
+
+- Exact `main` head CI and CodeQL succeeded in GitHub Actions run `32370680456` and run `32370680461`.
+- Android registration/sign-in smoke passed manually on the rebased client-feature descendant stack.
+- Physical iOS registration and authentication passed on iOS 26.6 with a correctly provisioned Associated Domains entitlement; all four start/finish requests returned HTTP 200. The tested descendant includes current `main`, so it exercises the release architecture plus the still-open additive client feature stack.
+- The physical smokes were not run from the exact release branch. Review of the intervening additive stack found the default iOS registration request construction semantically preserved and the authentication path unchanged; exact-head automated iOS/Android compilation and tests remain mandatory on the release PR.
+- Local gates are complete; the release PR must still pass the current-head GitHub checks below.
+
+## Required Pre-Publication Gates
+
+- `tools/agent/verify-harness-sync.sh`
+- `tools/agent/quality-gate.sh --mode strict --scope full --block true`
+- `./gradlew apiCheck --stacktrace`
+- `./gradlew publishToMavenLocal --stacktrace` with a configured signatory, or the documented credential-free `-PsignAllPublications=false` preflight when release keys are intentionally unavailable locally
+- `bash tools/agent/check-published-consumer-smoke.sh`
+- Release-note extraction for `0.4.0` produces the reviewed `CHANGELOG.md` section.
+- Release PR current-head CI, dependency review, CodeQL, and release preflight are green.
+
+## Completed Local Gates
+
+- `tools/agent/quality-gate.sh --mode fast --scope changed --block false`: passed.
+- `tools/agent/quality-gate.sh --mode strict --scope full --block true`: passed.
+- `./gradlew apiCheck --stacktrace`: passed.
+- `./gradlew publishToMavenLocal --stacktrace`: reached publication assembly but could not sign because this workstation has no configured PGP signatory.
+- `./gradlew publishToMavenLocal -PsignAllPublications=false --stacktrace`: passed, matching CI's credential-free publication preflight.
+- `bash tools/agent/check-published-consumer-smoke.sh`: passed against Maven Local `0.4.0` artifacts on JVM, Android, and iOS Simulator targets, including the must-use consumer probe.
+- `bash tools/agent/check-client-dependency-purity.sh`: passed for the replaceable JSON, Ktor, platform, and server seams.
+- Release-note extraction tests, harness synchronization, workflow YAML parsing, and `git diff --check`: passed.
+- Repository Actions secrets still include the required Central username/password and signing key/id/password names; their values remain intentionally unreadable and will only be exercised by the approval-gated publish workflow.
+
+## Approval Gate And Publication
+
+Do not create a tag, publish to Maven Central, create/publish a GitHub Release, or dispatch the `Publish` workflow without explicit maintainer approval after the release PR is merged and final `main` checks pass.
+
+After approval, dispatch `.github/workflows/publish.yml` on `main` with `release_mode=publish-and-release` and `version_name=0.4.0`. Verify all coordinated artifacts and the BOM resolve from Maven Central, and verify tag/release `v0.4.0` points at the approved `main` SHA with the curated changelog section as its body.
+
+## Post-Release Cleanup
+
+- Open a cleanup PR setting `VERSION_NAME=0.4.1-SNAPSHOT`.
+- Remove this temporary execution map after Central/tag/release verification is complete.
+- Re-run the consumer smoke against Maven Central `0.4.0` rather than Maven Local.
+- Keep the open client feature stack out of `0.4.0` unless it is intentionally merged before the approval gate and the release delta is re-audited.
+
+## Follow-Ups Not Blocking Current Main
+
+- PR #172 explicitly retains a real cross-device Android Restore Credentials backup/restore validation gate. Do not ship that feature until the gate is satisfied or the scope/readiness claim is revised.
+- PRs #170/#172/#171 are a separate additive client feature stack and require their own merge decision/current-head CI after each parent lands.
+- Draft PR #202 is an opt-in community FIDO registration compatibility canary, not official FIDO certification or a prerequisite for `0.4.0`.

--- a/docs/ai/WORKFLOWS.md
+++ b/docs/ai/WORKFLOWS.md
@@ -115,7 +115,8 @@ tools/agent/quality-gate.sh --mode strict --scope full --block true
 ## Release-Prep Workflow
 
 1. For complex release initiatives, keep a temporary release execution-map doc under `docs/ai/` current while the effort is active.
-2. Validate compatibility and publishing preflight:
+2. Add a versioned `CHANGELOG.md` section containing the curated GitHub Release notes. The publish workflow validates this section before Central publication.
+3. Validate compatibility and publishing preflight:
 
 <!-- doc-example: id=docs-ai-workflows-bash-11; owner=markdown; verify=syntax; audience=contributor -->
 ```bash
@@ -123,5 +124,7 @@ tools/agent/quality-gate.sh --mode strict --scope full --block true
 bash tools/agent/check-published-consumer-smoke.sh
 ```
 
-3. For a live release, use `.github/workflows/publish.yml` via `workflow_dispatch`.
-4. After the release effort is complete, delete the temporary release execution-map doc in the cleanup PR.
+On a workstation without a release signing key, use the credential-free Maven Local preflight documented in `docs/MAVEN_CENTRAL.md`; the approval-gated live workflow must still sign every publication.
+
+4. For a live release, use `.github/workflows/publish.yml` via `workflow_dispatch`. Its Central job has read-only repository access and no persisted Git credentials; only the post-publication GitHub Release job receives `contents:write`.
+5. After the release effort is complete, delete the temporary release execution-map doc in the cleanup PR.

--- a/documentation/example-inventory.md
+++ b/documentation/example-inventory.md
@@ -64,7 +64,7 @@ Managed blocks: **111**
 | docs-client-first-execution-bash-1 | docs/CLIENT_FIRST_EXECUTION.md:94 | Local Backend App (`sample/backend-ktor`) | bash | consumer | markdown | Markdown block | syntax |  |
 | docs-client-first-execution-bash-2 | docs/CLIENT_FIRST_EXECUTION.md:101 | Local Backend App (`sample/backend-ktor`) | bash | consumer | markdown | Markdown block | syntax |  |
 | docs-client-first-execution-kotlin-2 | docs/CLIENT_FIRST_EXECUTION.md:173 | `webauthn-client-json-core` (optional) | kotlin | consumer | source | documentation/examples/src/androidMain/kotlin/dev/webauthn/documentation/examples/AndroidJsonClientExample.kt#android-json-client | platform-compile |  |
-| docs-maven-central-bash-1 | docs/MAVEN_CENTRAL.md:69 | Local Validation | bash | contributor | markdown | Markdown block | syntax |  |
+| docs-maven-central-bash-1 | docs/MAVEN_CENTRAL.md:71 | Local Validation | bash | contributor | markdown | Markdown block | syntax |  |
 | docs-ai-workflows-bash-1 | docs/ai/WORKFLOWS.md:10 | Standard Change Workflow | bash | contributor | markdown | Markdown block | syntax |  |
 | docs-ai-workflows-bash-2 | docs/ai/WORKFLOWS.md:17 | Standard Change Workflow | bash | contributor | markdown | Markdown block | syntax |  |
 | docs-ai-workflows-bash-3 | docs/ai/WORKFLOWS.md:24 | Standard Change Workflow | bash | contributor | markdown | Markdown block | syntax |  |
@@ -75,7 +75,7 @@ Managed blocks: **111**
 | docs-ai-workflows-bash-8 | docs/ai/WORKFLOWS.md:92 | Public Security Hygiene Workflow | bash | contributor | markdown | Markdown block | syntax |  |
 | docs-ai-workflows-bash-9 | docs/ai/WORKFLOWS.md:99 | Public Security Hygiene Workflow | bash | contributor | markdown | Markdown block | syntax |  |
 | docs-ai-workflows-bash-10 | docs/ai/WORKFLOWS.md:111 | Full Validation Workflow | bash | contributor | markdown | Markdown block | syntax |  |
-| docs-ai-workflows-bash-11 | docs/ai/WORKFLOWS.md:121 | Release-Prep Workflow | bash | contributor | markdown | Markdown block | syntax |  |
+| docs-ai-workflows-bash-11 | docs/ai/WORKFLOWS.md:122 | Release-Prep Workflow | bash | contributor | markdown | Markdown block | syntax |  |
 | docs-architecture-mermaid-1 | docs/architecture.md:32 | Reference integration | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
 | docs-architecture-mermaid-2 | docs/architecture.md:58 | Shared foundation | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
 | docs-architecture-mermaid-3 | docs/architecture.md:91 | Client stack | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ android.useAndroidX=true
 
 # Publishing
 GROUP=io.github.szijpeter
-VERSION_NAME=0.3.1-SNAPSHOT
+VERSION_NAME=0.4.0
 mavenCentralPublishing=true
 signAllPublications=true
 mavenCentralAutomaticPublishing=false

--- a/tools/agent/extract-release-notes-test.sh
+++ b/tools/agent/extract-release-notes-test.sh
@@ -35,8 +35,39 @@ printf '%s\n' \
 bash "$ROOT_DIR/tools/agent/extract-release-notes.sh" 1.2.0 "$fixture" "$actual"
 cmp "$expected" "$actual"
 
+printf '%s\n' 'preserve-existing-output' > "$actual"
 if bash "$ROOT_DIR/tools/agent/extract-release-notes.sh" 9.9.9 "$fixture" "$actual" 2>/dev/null; then
     echo "Missing release sections must fail extraction." >&2
+    exit 1
+fi
+printf '%s\n' 'preserve-existing-output' | cmp - "$actual"
+
+fixture_before="$tmp_dir/CHANGELOG.before.md"
+cp "$fixture" "$fixture_before"
+if bash "$ROOT_DIR/tools/agent/extract-release-notes.sh" 1.2.0 "$fixture" "$fixture" 2>/dev/null; then
+    echo "In-place extraction must be rejected." >&2
+    exit 1
+fi
+cmp "$fixture_before" "$fixture"
+
+hard_link="$tmp_dir/CHANGELOG.hard-link.md"
+ln "$fixture" "$hard_link"
+if bash "$ROOT_DIR/tools/agent/extract-release-notes.sh" 1.2.0 "$fixture" "$hard_link" 2>/dev/null; then
+    echo "Hard-linked output must be rejected." >&2
+    exit 1
+fi
+cmp "$fixture_before" "$fixture"
+
+symbolic_link="$tmp_dir/CHANGELOG.symbolic-link.md"
+ln -s "$fixture" "$symbolic_link"
+if bash "$ROOT_DIR/tools/agent/extract-release-notes.sh" 1.2.0 "$fixture" "$symbolic_link" 2>/dev/null; then
+    echo "Symbolic-linked output must be rejected." >&2
+    exit 1
+fi
+cmp "$fixture_before" "$fixture"
+
+if bash "$ROOT_DIR/tools/agent/extract-release-notes.sh" 1.2.0 "$fixture" "$tmp_dir" 2>/dev/null; then
+    echo "Directory output must be rejected." >&2
     exit 1
 fi
 

--- a/tools/agent/extract-release-notes-test.sh
+++ b/tools/agent/extract-release-notes-test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'find "$tmp_dir" -depth -delete' EXIT
+
+fixture="$tmp_dir/CHANGELOG.md"
+actual="$tmp_dir/actual.md"
+expected="$tmp_dir/expected.md"
+
+printf '%s\n' \
+    '# Changelog' \
+    '' \
+    '## Unreleased' \
+    '' \
+    '## 1.2.0 - 2026-08-23' \
+    '' \
+    '### Added' \
+    '' \
+    '- First.' \
+    '' \
+    '## 1.1.0 - 2026-08-01' \
+    '' \
+    '- Older.' > "$fixture"
+
+printf '%s\n' \
+    '## 1.2.0 - 2026-08-23' \
+    '' \
+    '### Added' \
+    '' \
+    '- First.' \
+    '' > "$expected"
+
+bash "$ROOT_DIR/tools/agent/extract-release-notes.sh" 1.2.0 "$fixture" "$actual"
+cmp "$expected" "$actual"
+
+if bash "$ROOT_DIR/tools/agent/extract-release-notes.sh" 9.9.9 "$fixture" "$actual" 2>/dev/null; then
+    echo "Missing release sections must fail extraction." >&2
+    exit 1
+fi
+
+echo "Release notes extraction: PASS"

--- a/tools/agent/extract-release-notes.sh
+++ b/tools/agent/extract-release-notes.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+    echo "Usage: tools/agent/extract-release-notes.sh <version> <changelog> <output>" >&2
+    exit 2
+fi
+
+version="$1"
+changelog="$2"
+output="$3"
+
+if [[ -z "$version" ]]; then
+    echo "Release version must not be empty." >&2
+    exit 2
+fi
+
+if [[ ! -f "$changelog" ]]; then
+    echo "Changelog not found: $changelog" >&2
+    exit 2
+fi
+
+awk -v version="$version" '
+    found && /^## / { exit }
+    index($0, "## " version " - ") == 1 { found = 1 }
+    found { print }
+    END {
+        if (!found) {
+            print "Missing changelog section for version " version > "/dev/stderr"
+            exit 3
+        }
+    }
+' "$changelog" > "$output"
+
+if [[ ! -s "$output" ]]; then
+    echo "Extracted release notes are empty for version $version." >&2
+    exit 3
+fi

--- a/tools/agent/extract-release-notes.sh
+++ b/tools/agent/extract-release-notes.sh
@@ -20,6 +20,29 @@ if [[ ! -f "$changelog" ]]; then
     exit 2
 fi
 
+if [[ -e "$output" && "$changelog" -ef "$output" ]]; then
+    echo "Changelog and output must be different files." >&2
+    exit 2
+fi
+
+if [[ -d "$output" ]]; then
+    echo "Output must be a file path: $output" >&2
+    exit 2
+fi
+
+output_dir="$(dirname "$output")"
+output_name="$(basename "$output")"
+if [[ ! -d "$output_dir" ]]; then
+    echo "Output directory not found: $output_dir" >&2
+    exit 2
+fi
+
+tmp_output="$(mktemp "$output_dir/.${output_name}.tmp.XXXXXX")"
+cleanup() {
+    rm -f "$tmp_output"
+}
+trap cleanup EXIT
+
 awk -v version="$version" '
     found && /^## / { exit }
     index($0, "## " version " - ") == 1 { found = 1 }
@@ -30,9 +53,12 @@ awk -v version="$version" '
             exit 3
         }
     }
-' "$changelog" > "$output"
+' "$changelog" > "$tmp_output"
 
-if [[ ! -s "$output" ]]; then
+if [[ ! -s "$tmp_output" ]]; then
     echo "Extracted release notes are empty for version $version." >&2
     exit 3
 fi
+
+mv "$tmp_output" "$output"
+trap - EXIT

--- a/tools/agent/verify-harness-sync.sh
+++ b/tools/agent/verify-harness-sync.sh
@@ -26,6 +26,8 @@ required_files=(
   ".gemini/workflows/fast-pr-check.md"
   "tools/agent/quality-gate.sh"
   "tools/agent/check-published-consumer-smoke.sh"
+  "tools/agent/extract-release-notes.sh"
+  "tools/agent/extract-release-notes-test.sh"
   "tools/agent/modern-bash.sh"
   "tools/agent/changed-modules.sh"
   "tools/agent/spec-trace-check.sh"


### PR DESCRIPTION
## Summary

- prepare the coordinated `0.4.0` release from latest `v0.3.0`
- publish a curated changelog covering additions, fixes, removals, security changes, and migration-breaking API/artifact changes
- set the release version and record scope, mobile evidence, follow-ups, approval gate, and post-release cleanup
- make GitHub Release notes come from the reviewed changelog while isolating `contents:write` from the Central publishing job
- synchronize publishing/security guidance and validate release-note extraction in CI

## Release assessment

- no code or architecture blocker was found in current `main`
- Android and physical-iOS register/sign-in smokes passed on the additive client-stack descendant; exact release head `ac5a6fd` also passed the full current-head CI suite, including Android, iOS compile, API compatibility, documentation, and release preflight
- PRs #170/#172/#171 and draft #202 remain outside `0.4.0`
- #172's real cross-device Restore Credentials validation remains a gate for that later feature, not this release
- publication/tag/GitHub Release creation remains manual and requires explicit maintainer approval after this PR merges and final `main` checks pass

## Validation

- `tools/agent/quality-gate.sh --mode strict --scope full --block true`
- `./gradlew apiCheck --stacktrace`
- `./gradlew publishToMavenLocal -PsignAllPublications=false --stacktrace`
- `bash tools/agent/check-published-consumer-smoke.sh`
- `bash tools/agent/check-client-dependency-purity.sh`
- release-note extraction tests, harness synchronization, workflow YAML parsing, and `git diff --check`

The exact signed Maven Local command was also attempted; artifact assembly succeeded and it stopped only because this workstation intentionally has no configured PGP signatory. The live workflow retains mandatory signing and the required repository secret names are configured.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Release**
  - Updated the published version to **0.4.0**.
  - Added codec-neutral artifacts, generic passkey flows, client composition modules, and username-optional authentication.
  - Added security improvements, compliance checks, and fixes for authentication flow errors and continuation state.
  - Removed superseded controllers, clients, and artifacts.

- **Documentation**
  - Added comprehensive 0.4.0 changelog and release planning guidance.
  - Updated Maven Central publication and security documentation.

- **Quality Improvements**
  - Added automated validation for curated release-note extraction and publication readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
