### PR TITLE
ci: update Diff Breakdown to v0.2.0

### DIFF
--- a/.github/workflows/diff-breakdown.yml
+++ b/.github/workflows/diff-breakdown.yml
@@ -28,7 +28,7 @@ jobs:
       # action is pinned to an immutable commit, reads configuration from the
       # exact PR base commit, and never checks out or executes the PR head.
       - name: Build diff breakdown
-        uses: szijpeter/diff-breakdown@bc613f9011374a65acc55202084142bce3e3cf6a # v0.1.0
+        uses: szijpeter/diff-breakdown@d42c30f746cd204404b321fbae10693d82cd3ce7 # v0.2.0
         with:
           token: ${{ github.token }}
           pr-number: ${{ github.event.pull_request.number || inputs.pr_number }}


### PR DESCRIPTION
## Summary

- pin Diff Breakdown to the immutable `v0.2.0` release commit
- adopt the compact report layout and collapsed visualization appendix
- preserve the existing privileged-workflow permissions and trusted-base configuration model

## Checks

- [x] `tools/agent/quality-gate.sh --mode fast --scope changed --block false`
- [x] `tools/agent/quality-gate.sh --mode strict --scope changed --block false`
- [x] `apiCheck` not required; no BCV-covered API changed
- [x] `publishToMavenLocal` not required; no publishing metadata changed

## Docs

- [x] Strict docs trace passed; no public API, integration path, release workflow, or security posture changed

## Notes

- [Diff Breakdown v0.2.0](https://github.com/szijpeter/diff-breakdown/releases/tag/v0.2.0)
- exact action commit: `d42c30f746cd204404b321fbae10693d82cd3ce7`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated change-summary workflow to use the latest version of its analysis action.
  * Maintained the workflow’s existing behavior while applying the updated action revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->