### PR TITLE
feat(swift): add native bridge foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,27 @@ jobs:
       - name: iOS Host App Compile
         run: xcodebuild -project sample/compose-passkey-ios/ComposePasskeyIos.xcodeproj -scheme ComposePasskeyIos -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build
 
+  swift-bridge:
+    runs-on: macos-26
+    needs: [harness]
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@v6
+        with:
+          distribution: temurin
+          java-version: '21'
+      - uses: gradle/actions/setup-gradle@v6
+      - name: Swift Bridge Checks
+        run: |
+          ./gradlew \
+            :client:webauthn-client-swift-bridge:iosSimulatorArm64Test \
+            :client:webauthn-client-swift-bridge:assembleWebAuthnBridgeReleaseXCFramework \
+            --stacktrace
+          tools/swift/check-xcframework.sh
+
   release-preflight:
     runs-on: macos-latest
     needs: [harness, api-compatibility]

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ temp.server/node_modules/
 
 # Local Python virtual environments
 .venv/
+__pycache__/
+*.py[cod]
 
 # Local standards/spec cache artifacts (keep cache docs tracked)
 spec-cache/**/*

--- a/client/webauthn-client-swift-bridge/README.md
+++ b/client/webauthn-client-swift-bridge/README.md
@@ -1,0 +1,31 @@
+# webauthn-client-swift-bridge
+
+Internal Kotlin/Native bridge used by the public `WebAuthn` Swift package.
+
+This module deliberately exposes only a narrow, non-generic Objective-C/Swift boundary. Native Swift consumers should import the source facade from the repository's Swift package and must not depend on `WebAuthnBridge` directly.
+
+The bridge owns no WebAuthn semantics. It delegates JSON decoding and encoding, passkey ceremonies,
+capability reporting, and PRF request/result mapping to the existing Kotlin modules. The source-based
+Swift facade derives and contains its PRF session key with CryptoKit, guarded by cross-language vectors.
+
+The release XCFramework is static, includes privacy and legal notices in every slice, and is post-processed
+to remove build-machine debug metadata. Release consumers receive it only through the checksum-pinned
+`WebAuthn` Swift package manifest.
+
+Supported Apple targets:
+
+- iOS arm64 devices
+- iOS arm64 simulators
+
+Intel simulator support is not currently advertised; release validation covers arm64 devices and Apple
+Silicon simulators.
+
+Build the local binary with:
+
+<!-- doc-example: id=client-webauthn-client-swift-bridge-readme-bash-1; owner=markdown; verify=syntax; audience=contributor -->
+```bash
+./gradlew :client:webauthn-client-swift-bridge:assembleWebAuthnBridgeReleaseXCFramework --stacktrace
+```
+
+Run `tools/swift/check-xcframework.sh` after assembly. Native Swift applications should follow
+[`swift/README.md`](../../swift/README.md) and must not import this module directly.

--- a/client/webauthn-client-swift-bridge/api/webauthn-client-swift-bridge.klib.api
+++ b/client/webauthn-client-swift-bridge/api/webauthn-client-swift-bridge.klib.api
@@ -1,0 +1,50 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <io.github.szijpeter:webauthn-client-swift-bridge>
+final class dev.webauthn.client.swift/SwiftPasskeyBridge { // dev.webauthn.client.swift/SwiftPasskeyBridge|null[0]
+    constructor <init>() // dev.webauthn.client.swift/SwiftPasskeyBridge.<init>|<init>(){}[0]
+
+    final fun updatePresentationAnchor(platform.UIKit/UIWindow?) // dev.webauthn.client.swift/SwiftPasskeyBridge.updatePresentationAnchor|updatePresentationAnchor(platform.UIKit.UIWindow?){}[0]
+    final suspend fun authenticateWithPrf(kotlin/String, kotlin/String, kotlin/String?): dev.webauthn.client.swift/SwiftPrfAuthenticationBridgeResult // dev.webauthn.client.swift/SwiftPasskeyBridge.authenticateWithPrf|authenticateWithPrf(kotlin.String;kotlin.String;kotlin.String?){}[0]
+    final suspend fun capabilities(): dev.webauthn.client.swift/SwiftPasskeyBridgeCapabilities // dev.webauthn.client.swift/SwiftPasskeyBridge.capabilities|capabilities(){}[0]
+    final suspend fun createCredential(kotlin/String): dev.webauthn.client.swift/SwiftPasskeyBridgeResult // dev.webauthn.client.swift/SwiftPasskeyBridge.createCredential|createCredential(kotlin.String){}[0]
+    final suspend fun getAssertion(kotlin/String): dev.webauthn.client.swift/SwiftPasskeyBridgeResult // dev.webauthn.client.swift/SwiftPasskeyBridge.getAssertion|getAssertion(kotlin.String){}[0]
+}
+
+final class dev.webauthn.client.swift/SwiftPasskeyBridgeCapabilities { // dev.webauthn.client.swift/SwiftPasskeyBridgeCapabilities|null[0]
+    final val reportedCount // dev.webauthn.client.swift/SwiftPasskeyBridgeCapabilities.reportedCount|{}reportedCount[0]
+        final fun <get-reportedCount>(): kotlin/Int // dev.webauthn.client.swift/SwiftPasskeyBridgeCapabilities.reportedCount.<get-reportedCount>|<get-reportedCount>(){}[0]
+    final val valuesJson // dev.webauthn.client.swift/SwiftPasskeyBridgeCapabilities.valuesJson|{}valuesJson[0]
+        final fun <get-valuesJson>(): kotlin/String // dev.webauthn.client.swift/SwiftPasskeyBridgeCapabilities.valuesJson.<get-valuesJson>|<get-valuesJson>(){}[0]
+}
+
+final class dev.webauthn.client.swift/SwiftPasskeyBridgeResult { // dev.webauthn.client.swift/SwiftPasskeyBridgeResult|null[0]
+    final val errorCode // dev.webauthn.client.swift/SwiftPasskeyBridgeResult.errorCode|{}errorCode[0]
+        final fun <get-errorCode>(): kotlin/String? // dev.webauthn.client.swift/SwiftPasskeyBridgeResult.errorCode.<get-errorCode>|<get-errorCode>(){}[0]
+    final val errorMessage // dev.webauthn.client.swift/SwiftPasskeyBridgeResult.errorMessage|{}errorMessage[0]
+        final fun <get-errorMessage>(): kotlin/String? // dev.webauthn.client.swift/SwiftPasskeyBridgeResult.errorMessage.<get-errorMessage>|<get-errorMessage>(){}[0]
+    final val isSuccess // dev.webauthn.client.swift/SwiftPasskeyBridgeResult.isSuccess|{}isSuccess[0]
+        final fun <get-isSuccess>(): kotlin/Boolean // dev.webauthn.client.swift/SwiftPasskeyBridgeResult.isSuccess.<get-isSuccess>|<get-isSuccess>(){}[0]
+    final val responseJson // dev.webauthn.client.swift/SwiftPasskeyBridgeResult.responseJson|{}responseJson[0]
+        final fun <get-responseJson>(): kotlin/String? // dev.webauthn.client.swift/SwiftPasskeyBridgeResult.responseJson.<get-responseJson>|<get-responseJson>(){}[0]
+}
+
+final class dev.webauthn.client.swift/SwiftPrfAuthenticationBridgeResult { // dev.webauthn.client.swift/SwiftPrfAuthenticationBridgeResult|null[0]
+    final val errorCode // dev.webauthn.client.swift/SwiftPrfAuthenticationBridgeResult.errorCode|{}errorCode[0]
+        final fun <get-errorCode>(): kotlin/String? // dev.webauthn.client.swift/SwiftPrfAuthenticationBridgeResult.errorCode.<get-errorCode>|<get-errorCode>(){}[0]
+    final val errorMessage // dev.webauthn.client.swift/SwiftPrfAuthenticationBridgeResult.errorMessage|{}errorMessage[0]
+        final fun <get-errorMessage>(): kotlin/String? // dev.webauthn.client.swift/SwiftPrfAuthenticationBridgeResult.errorMessage.<get-errorMessage>|<get-errorMessage>(){}[0]
+    final val firstResultBase64Url // dev.webauthn.client.swift/SwiftPrfAuthenticationBridgeResult.firstResultBase64Url|{}firstResultBase64Url[0]
+        final fun <get-firstResultBase64Url>(): kotlin/String? // dev.webauthn.client.swift/SwiftPrfAuthenticationBridgeResult.firstResultBase64Url.<get-firstResultBase64Url>|<get-firstResultBase64Url>(){}[0]
+    final val isSuccess // dev.webauthn.client.swift/SwiftPrfAuthenticationBridgeResult.isSuccess|{}isSuccess[0]
+        final fun <get-isSuccess>(): kotlin/Boolean // dev.webauthn.client.swift/SwiftPrfAuthenticationBridgeResult.isSuccess.<get-isSuccess>|<get-isSuccess>(){}[0]
+    final val responseJson // dev.webauthn.client.swift/SwiftPrfAuthenticationBridgeResult.responseJson|{}responseJson[0]
+        final fun <get-responseJson>(): kotlin/String? // dev.webauthn.client.swift/SwiftPrfAuthenticationBridgeResult.responseJson.<get-responseJson>|<get-responseJson>(){}[0]
+    final val secondResultBase64Url // dev.webauthn.client.swift/SwiftPrfAuthenticationBridgeResult.secondResultBase64Url|{}secondResultBase64Url[0]
+        final fun <get-secondResultBase64Url>(): kotlin/String? // dev.webauthn.client.swift/SwiftPrfAuthenticationBridgeResult.secondResultBase64Url.<get-secondResultBase64Url>|<get-secondResultBase64Url>(){}[0]
+}

--- a/client/webauthn-client-swift-bridge/build.gradle.kts
+++ b/client/webauthn-client-swift-bridge/build.gradle.kts
@@ -1,0 +1,83 @@
+import co.touchlab.skie.configuration.EnumInterop
+import co.touchlab.skie.configuration.FlowInterop
+import co.touchlab.skie.configuration.SealedInterop
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
+
+plugins {
+    id("webauthn.kotlin.multiplatform")
+    alias(libs.plugins.skie)
+}
+
+skie {
+    analytics {
+        enabled.set(false)
+    }
+    build {
+        produceDistributableFramework()
+    }
+    features {
+        group {
+            FlowInterop.Enabled(false)
+            EnumInterop.Enabled(false)
+            SealedInterop.Enabled(false)
+        }
+    }
+}
+
+kotlin {
+    val appleFrameworkVersion = project.version
+        .toString()
+        .substringBefore('-')
+        .takeIf { it.matches(Regex("""\d+\.\d+\.\d+""")) }
+        ?: "0.0.0"
+    val webAuthnBridge = XCFramework("WebAuthnBridge")
+    listOf(
+        iosArm64(),
+        iosSimulatorArm64(),
+    ).forEach { target ->
+        target.binaries.framework {
+            baseName = "WebAuthnBridge"
+            isStatic = true
+            binaryOption("bundleId", "dev.webauthn.swift.bridge")
+            binaryOption("bundleShortVersionString", appleFrameworkVersion)
+            webAuthnBridge.add(this)
+        }
+    }
+
+    sourceSets {
+        iosMain.dependencies {
+            implementation(project(":client:webauthn-client-platform"))
+            implementation(project(":client:webauthn-client-json-core"))
+            implementation(project(":core:webauthn-json-kotlinx"))
+            implementation(project(":core:webauthn-runtime-core"))
+            implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.kotlinx.serialization.json)
+        }
+        iosTest.dependencies {
+            implementation(kotlin("test"))
+            implementation(libs.kotlinx.coroutines.test)
+        }
+    }
+}
+
+val privacyManifest = rootProject.layout.projectDirectory.file("swift/Resources/PrivacyInfo.xcprivacy")
+val projectLicense = rootProject.layout.projectDirectory.file("LICENSE")
+val thirdPartyNotices = rootProject.layout.projectDirectory.file("swift/THIRD_PARTY_NOTICES.txt")
+val releaseXCFramework = layout.buildDirectory.dir("XCFrameworks/release/WebAuthnBridge.xcframework")
+val assembleReleaseXCFramework = tasks.named("assembleWebAuthnBridgeReleaseXCFramework")
+val postprocessReleaseXCFramework = tasks.register<Exec>("postprocessWebAuthnBridgeReleaseXCFramework") {
+    dependsOn(assembleReleaseXCFramework)
+    inputs.file(privacyManifest)
+    inputs.file(projectLicense)
+    inputs.file(thirdPartyNotices)
+    commandLine(
+        rootProject.layout.projectDirectory.file("tools/swift/postprocess-xcframework.sh").asFile.absolutePath,
+        releaseXCFramework.get().asFile.absolutePath,
+        privacyManifest.asFile.absolutePath,
+        projectLicense.asFile.absolutePath,
+        thirdPartyNotices.asFile.absolutePath,
+    )
+}
+assembleReleaseXCFramework.configure {
+    finalizedBy(postprocessReleaseXCFramework)
+}

--- a/client/webauthn-client-swift-bridge/src/iosMain/kotlin/dev/webauthn/client/swift/SwiftBridgeModels.kt
+++ b/client/webauthn-client-swift-bridge/src/iosMain/kotlin/dev/webauthn/client/swift/SwiftBridgeModels.kt
@@ -1,0 +1,95 @@
+package dev.webauthn.client.swift
+
+import dev.webauthn.client.CapabilitySupport
+import dev.webauthn.client.PasskeyCapabilities
+import dev.webauthn.client.PasskeyCapability
+import dev.webauthn.client.PasskeyClientError
+import dev.webauthn.client.PlatformCapability
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+
+/** Stable, non-generic result exported only to the internal Swift adapter. */
+public class SwiftPasskeyBridgeResult internal constructor(
+    public val responseJson: String?,
+    public val errorCode: String?,
+    public val errorMessage: String?,
+) {
+    public val isSuccess: Boolean
+        get() = responseJson != null && errorCode == null && errorMessage == null
+}
+
+/** Capability snapshot serialized through a primitive JSON bridge boundary. */
+public class SwiftPasskeyBridgeCapabilities internal constructor(
+    public val valuesJson: String,
+    public val reportedCount: Int,
+)
+
+internal data class SwiftBridgeFailure(
+    val code: String,
+    val message: String,
+)
+
+internal fun success(responseJson: String): SwiftPasskeyBridgeResult =
+    SwiftPasskeyBridgeResult(
+        responseJson = responseJson,
+        errorCode = null,
+        errorMessage = null,
+    )
+
+internal fun failure(code: String, message: String): SwiftPasskeyBridgeResult =
+    SwiftPasskeyBridgeResult(
+        responseJson = null,
+        errorCode = code,
+        errorMessage = message,
+    )
+
+internal fun PasskeyClientError.toSwiftBridgeFailure(): SwiftBridgeFailure = when (this) {
+    is PasskeyClientError.UserCancelled -> SwiftBridgeFailure("userCancelled", message)
+    is PasskeyClientError.NoCredential -> SwiftBridgeFailure("noCredential", message)
+    is PasskeyClientError.InvalidOptions -> SwiftBridgeFailure("invalidOptions", message)
+    is PasskeyClientError.Platform -> SwiftBridgeFailure("platform", message)
+    is PasskeyClientError.Codec -> SwiftBridgeFailure("codec", message)
+}
+
+internal fun PasskeyCapabilities.toSwiftBridgeCapabilities(): SwiftPasskeyBridgeCapabilities {
+    val values = buildJsonArray {
+        support.entries
+            .sortedBy { (capability, _) -> capability.swiftSortKey() }
+            .forEach { (capability, support) ->
+                add(
+                    buildJsonObject {
+                        put("kind", JsonPrimitive(capability.swiftKind()))
+                        put("id", JsonPrimitive(capability.swiftIdentifier()))
+                        put("support", JsonPrimitive(support.swiftValue()))
+                    },
+                )
+            }
+    }
+    return SwiftPasskeyBridgeCapabilities(
+        valuesJson = Json.encodeToString(values),
+        reportedCount = support.size,
+    )
+}
+
+private fun PasskeyCapability.swiftSortKey(): String = "${swiftKind()}\u0000${swiftIdentifier()}"
+
+private fun PasskeyCapability.swiftKind(): String = when (this) {
+    is PasskeyCapability.Extension -> "extension"
+    is PasskeyCapability.Platform -> "platform"
+}
+
+private fun PasskeyCapability.swiftIdentifier(): String = when (this) {
+    is PasskeyCapability.Extension -> extension.identifier
+    is PasskeyCapability.Platform -> when (val value = feature) {
+        PlatformCapability.SecurityKey -> "securityKey"
+        is PlatformCapability.Custom -> value.id
+    }
+}
+
+private fun CapabilitySupport.swiftValue(): String = when (this) {
+    CapabilitySupport.SUPPORTED -> "supported"
+    CapabilitySupport.UNSUPPORTED -> "unsupported"
+    CapabilitySupport.UNKNOWN -> "unknown"
+}

--- a/client/webauthn-client-swift-bridge/src/iosMain/kotlin/dev/webauthn/client/swift/SwiftPasskeyBridge.kt
+++ b/client/webauthn-client-swift-bridge/src/iosMain/kotlin/dev/webauthn/client/swift/SwiftPasskeyBridge.kt
@@ -1,0 +1,157 @@
+package dev.webauthn.client.swift
+
+import dev.webauthn.client.DefaultJsonPasskeyClient
+import dev.webauthn.client.JsonPasskeyClient
+import dev.webauthn.client.PasskeyClient
+import dev.webauthn.client.PasskeyResult
+import dev.webauthn.client.ios.IosPasskeyClient
+import dev.webauthn.client.ios.MutablePasskeyPresentationAnchorProvider
+import dev.webauthn.runtime.rethrowCancellationOrFatal
+import dev.webauthn.serialization.KotlinxWebAuthnJsonCodec
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import platform.Foundation.NSThread
+import platform.UIKit.UIWindow
+
+/** Internal Kotlin entry point consumed by the source-based WebAuthn Swift facade. */
+public class SwiftPasskeyBridge private constructor(
+    dependencies: SwiftBridgeDependencies,
+) {
+    private val anchorProvider: MutablePasskeyPresentationAnchorProvider = dependencies.anchorProvider
+    private val passkeyClient: PasskeyClient = dependencies.passkeyClient
+    private val jsonClient: JsonPasskeyClient = dependencies.jsonClient
+    private val prfBridge: SwiftPrfBridge = dependencies.prfBridge
+    private var operationInProgress: Boolean = false
+
+    public constructor() : this(defaultDependencies())
+
+    internal constructor(
+        passkeyClient: PasskeyClient,
+        jsonClient: JsonPasskeyClient,
+    ) : this(testDependencies(passkeyClient, jsonClient))
+
+    /** Updates the window used by the next AuthenticationServices ceremony. */
+    public fun updatePresentationAnchor(window: UIWindow?) {
+        check(NSThread.isMainThread) {
+            "The presentation anchor must be updated on the main thread."
+        }
+        anchorProvider.update(window)
+    }
+
+    /** Executes registration from Kotlin-owned WebAuthn JSON decoding through response encoding. */
+    public suspend fun createCredential(requestJson: String): SwiftPasskeyBridgeResult =
+        runCeremony { jsonClient.createCredentialJson(requestJson).toBridgeResult() }
+
+    /** Executes authentication from Kotlin-owned WebAuthn JSON decoding through response encoding. */
+    public suspend fun getAssertion(requestJson: String): SwiftPasskeyBridgeResult =
+        runCeremony { jsonClient.getAssertionJson(requestJson).toBridgeResult() }
+
+    /** Authenticates with PRF and returns the response plus raw authenticator outputs. */
+    @Suppress("TooGenericExceptionCaught")
+    public suspend fun authenticateWithPrf(
+        requestJson: String,
+        firstSaltBase64Url: String,
+        secondSaltBase64Url: String?,
+    ): SwiftPrfAuthenticationBridgeResult {
+        return try {
+            runExclusive {
+                prfBridge.authenticate(
+                    requestJson = requestJson,
+                    firstSaltBase64Url = firstSaltBase64Url,
+                    secondSaltBase64Url = secondSaltBase64Url,
+                )
+            }
+        } catch (_: OperationInProgressException) {
+            prfFailure(
+                code = "operationInProgress",
+                message = "Another passkey ceremony is already in progress.",
+            )
+        } catch (error: Throwable) {
+            error.rethrowCancellationOrFatal()
+            prfFailure(
+                code = "bridgeContract",
+                message = "The internal PRF bridge failed.",
+            )
+        }
+    }
+
+    /** Returns the platform capability snapshot through a primitive JSON boundary. */
+    public suspend fun capabilities(): SwiftPasskeyBridgeCapabilities =
+        withContext(Dispatchers.Main.immediate) {
+            passkeyClient.capabilities().toSwiftBridgeCapabilities()
+        }
+
+    internal suspend fun <T> runExclusive(block: suspend () -> T): T =
+        withContext(Dispatchers.Main.immediate) {
+            if (operationInProgress) {
+                throw OperationInProgressException()
+            }
+            operationInProgress = true
+            try {
+                block()
+            } finally {
+                operationInProgress = false
+            }
+        }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun runCeremony(
+        operation: suspend () -> SwiftPasskeyBridgeResult,
+    ): SwiftPasskeyBridgeResult {
+        return try {
+            runExclusive(operation)
+        } catch (_: OperationInProgressException) {
+            failure(
+                code = "operationInProgress",
+                message = "Another passkey ceremony is already in progress.",
+            )
+        } catch (error: Throwable) {
+            error.rethrowCancellationOrFatal()
+            failure(
+                code = "bridgeContract",
+                message = "The internal passkey bridge failed.",
+            )
+        }
+    }
+}
+
+private class OperationInProgressException : IllegalStateException()
+
+private class SwiftBridgeDependencies(
+    val anchorProvider: MutablePasskeyPresentationAnchorProvider,
+    val passkeyClient: PasskeyClient,
+    val jsonClient: JsonPasskeyClient,
+    val prfBridge: SwiftPrfBridge,
+)
+
+private fun defaultDependencies(): SwiftBridgeDependencies {
+    val anchorProvider = MutablePasskeyPresentationAnchorProvider()
+    val passkeyClient = IosPasskeyClient(anchorProvider)
+    val codec = KotlinxWebAuthnJsonCodec()
+    return SwiftBridgeDependencies(
+        anchorProvider = anchorProvider,
+        passkeyClient = passkeyClient,
+        jsonClient = DefaultJsonPasskeyClient(passkeyClient, codec),
+        prfBridge = SwiftPrfBridge(passkeyClient, codec),
+    )
+}
+
+private fun testDependencies(
+    passkeyClient: PasskeyClient,
+    jsonClient: JsonPasskeyClient,
+): SwiftBridgeDependencies {
+    val anchorProvider = MutablePasskeyPresentationAnchorProvider()
+    return SwiftBridgeDependencies(
+        anchorProvider = anchorProvider,
+        passkeyClient = passkeyClient,
+        jsonClient = jsonClient,
+        prfBridge = SwiftPrfBridge(passkeyClient),
+    )
+}
+
+private fun PasskeyResult<String>.toBridgeResult(): SwiftPasskeyBridgeResult = when (this) {
+    is PasskeyResult.Success -> success(value)
+    is PasskeyResult.Failure -> error.toSwiftBridgeFailure().let { failure ->
+        failure(failure.code, failure.message)
+    }
+}

--- a/client/webauthn-client-swift-bridge/src/iosMain/kotlin/dev/webauthn/client/swift/SwiftPrfBridge.kt
+++ b/client/webauthn-client-swift-bridge/src/iosMain/kotlin/dev/webauthn/client/swift/SwiftPrfBridge.kt
@@ -1,0 +1,96 @@
+@file:OptIn(dev.webauthn.model.ExperimentalWebAuthnL3Api::class)
+
+package dev.webauthn.client.swift
+
+import dev.webauthn.client.PasskeyClient
+import dev.webauthn.client.PasskeyResult
+import dev.webauthn.json.WebAuthnJsonCodec
+import dev.webauthn.model.AuthenticationExtensionsClientInputs
+import dev.webauthn.model.AuthenticationExtensionsPRFValues
+import dev.webauthn.model.Base64UrlBytes
+import dev.webauthn.model.PrfExtensionInput
+import dev.webauthn.model.ValidationResult
+import dev.webauthn.runtime.rethrowCancellationOrFatal
+import dev.webauthn.serialization.KotlinxWebAuthnJsonCodec
+
+/** Stable PRF authentication result exported only to the internal Swift adapter. */
+public class SwiftPrfAuthenticationBridgeResult internal constructor(
+    public val responseJson: String?,
+    public val firstResultBase64Url: String?,
+    public val secondResultBase64Url: String?,
+    public val errorCode: String?,
+    public val errorMessage: String?,
+) {
+    public val isSuccess: Boolean
+        get() = responseJson != null && firstResultBase64Url != null &&
+            errorCode == null && errorMessage == null
+}
+
+internal class SwiftPrfBridge(
+    private val passkeyClient: PasskeyClient,
+    private val codec: WebAuthnJsonCodec = KotlinxWebAuthnJsonCodec(),
+) {
+    @Suppress("TooGenericExceptionCaught")
+    suspend fun authenticate(
+        requestJson: String,
+        firstSaltBase64Url: String,
+        secondSaltBase64Url: String?,
+    ): SwiftPrfAuthenticationBridgeResult {
+        val options = when (val decoded = codec.decodeRequestOptions(requestJson)) {
+            is ValidationResult.Valid -> decoded.value
+            is ValidationResult.Invalid -> {
+                return prfFailure("invalidOptions", "Authentication options JSON is invalid.")
+            }
+        }
+        val salts = try {
+            AuthenticationExtensionsPRFValues(
+                first = Base64UrlBytes.parseOrThrow(firstSaltBase64Url, "firstSalt"),
+                second = secondSaltBase64Url?.let { Base64UrlBytes.parseOrThrow(it, "secondSalt") },
+            )
+        } catch (_: IllegalArgumentException) {
+            return prfFailure("invalidOptions", "A PRF salt is invalid.")
+        }
+        val existingExtensions = options.extensions ?: AuthenticationExtensionsClientInputs()
+        val optionsWithPrf = options.copy(
+            extensions = existingExtensions.copy(
+                prf = (existingExtensions.prf ?: PrfExtensionInput()).copy(
+                    eval = salts,
+                    evalByCredential = null,
+                ),
+            ),
+        )
+
+        return when (val result = passkeyClient.getAssertion(optionsWithPrf)) {
+            is PasskeyResult.Failure -> result.error.toSwiftBridgeFailure().let { failure ->
+                prfFailure(failure.code, failure.message)
+            }
+
+            is PasskeyResult.Success -> try {
+                val prfResults = result.value.extensions?.prf?.results
+                    ?: return prfFailure(
+                        "invalidOptions",
+                        "PRF extension was requested but no PRF results were returned by the authenticator.",
+                    )
+                SwiftPrfAuthenticationBridgeResult(
+                    responseJson = codec.encodeAuthenticationResponse(result.value),
+                    firstResultBase64Url = prfResults.first.encoded(),
+                    secondResultBase64Url = prfResults.second?.encoded(),
+                    errorCode = null,
+                    errorMessage = null,
+                )
+            } catch (error: Throwable) {
+                error.rethrowCancellationOrFatal()
+                prfFailure("codec", "Failed to encode authentication response JSON.")
+            }
+        }
+    }
+}
+
+internal fun prfFailure(code: String, message: String): SwiftPrfAuthenticationBridgeResult =
+    SwiftPrfAuthenticationBridgeResult(
+        responseJson = null,
+        firstResultBase64Url = null,
+        secondResultBase64Url = null,
+        errorCode = code,
+        errorMessage = message,
+    )

--- a/client/webauthn-client-swift-bridge/src/iosTest/kotlin/dev/webauthn/client/swift/SwiftPasskeyBridgeTest.kt
+++ b/client/webauthn-client-swift-bridge/src/iosTest/kotlin/dev/webauthn/client/swift/SwiftPasskeyBridgeTest.kt
@@ -1,0 +1,251 @@
+@file:OptIn(dev.webauthn.model.ExperimentalWebAuthnL3Api::class)
+
+package dev.webauthn.client.swift
+
+import dev.webauthn.client.CapabilitySupport
+import dev.webauthn.client.JsonPasskeyClient
+import dev.webauthn.client.PasskeyCapabilities
+import dev.webauthn.client.PasskeyCapability
+import dev.webauthn.client.PasskeyClient
+import dev.webauthn.client.PasskeyClientError
+import dev.webauthn.client.PasskeyResult
+import dev.webauthn.client.PlatformCapability
+import dev.webauthn.model.AuthenticationExtensionsClientOutputs
+import dev.webauthn.model.AuthenticationExtensionsPRFValues
+import dev.webauthn.model.Base64UrlBytes
+import dev.webauthn.model.Challenge
+import dev.webauthn.model.CredentialId
+import dev.webauthn.model.PrfExtensionOutput
+import dev.webauthn.model.PublicKeyCredentialCreationOptions
+import dev.webauthn.model.PublicKeyCredentialRequestOptions
+import dev.webauthn.model.RawAuthenticationResponse
+import dev.webauthn.model.RawRegistrationResponse
+import dev.webauthn.model.RpId
+import dev.webauthn.model.WebAuthnExtension
+import dev.webauthn.serialization.KotlinxWebAuthnJsonCodec
+import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SwiftPasskeyBridgeTest {
+    @Test
+    fun passkeyResultFactories_enforceSuccessAndFailureShapes() {
+        val success = success("{\"ok\":true}")
+        val failure = failure("platform", "Platform failed")
+
+        assertTrue(success.isSuccess)
+        assertNull(success.errorCode)
+        assertFalse(failure.isSuccess)
+        assertNull(failure.responseJson)
+    }
+
+    @Test
+    fun errorMapping_isExhaustiveAndStable() {
+        val mappings = [
+            PasskeyClientError.UserCancelled() to "userCancelled",
+            PasskeyClientError.NoCredential() to "noCredential",
+            PasskeyClientError.InvalidOptions("invalid") to "invalidOptions",
+            PasskeyClientError.Platform("platform") to "platform",
+            PasskeyClientError.Codec("codec") to "codec",
+        ]
+
+        mappings.forEach { (error, expectedCode) ->
+            assertEquals(expectedCode, error.toSwiftBridgeFailure().code)
+        }
+    }
+
+    @Test
+    fun capabilities_preserveKnownAndCustomIdentifiers() {
+        val capabilities = PasskeyCapabilities(
+            mapOf(
+                PasskeyCapability.Extension(WebAuthnExtension.Prf) to CapabilitySupport.SUPPORTED,
+                PasskeyCapability.Extension(WebAuthnExtension.LargeBlob) to CapabilitySupport.UNSUPPORTED,
+                PasskeyCapability.Platform(PlatformCapability.SecurityKey) to CapabilitySupport.UNKNOWN,
+                PasskeyCapability.Platform(PlatformCapability.Custom("hybridTransport")) to
+                    CapabilitySupport.SUPPORTED,
+            ),
+        ).toSwiftBridgeCapabilities()
+
+        assertEquals(4, capabilities.reportedCount)
+        assertEquals(
+            "[{\"kind\":\"extension\",\"id\":\"largeBlob\",\"support\":\"unsupported\"}," +
+                "{\"kind\":\"extension\",\"id\":\"prf\",\"support\":\"supported\"}," +
+                "{\"kind\":\"platform\",\"id\":\"hybridTransport\",\"support\":\"supported\"}," +
+                "{\"kind\":\"platform\",\"id\":\"securityKey\",\"support\":\"unknown\"}]",
+            capabilities.valuesJson,
+        )
+    }
+
+    @Test
+    fun capabilities_preserveCollidingExtensionAndPlatformIdentifiers() {
+        val capabilities = PasskeyCapabilities(
+            mapOf(
+                PasskeyCapability.Extension(WebAuthnExtension.Custom("securityKey")) to
+                    CapabilitySupport.SUPPORTED,
+                PasskeyCapability.Platform(PlatformCapability.SecurityKey) to
+                    CapabilitySupport.UNKNOWN,
+            ),
+        ).toSwiftBridgeCapabilities()
+
+        assertEquals(2, capabilities.reportedCount)
+        assertEquals(
+            "[{\"kind\":\"extension\",\"id\":\"securityKey\",\"support\":\"supported\"}," +
+                "{\"kind\":\"platform\",\"id\":\"securityKey\",\"support\":\"unknown\"}]",
+            capabilities.valuesJson,
+        )
+    }
+
+    @Test
+    fun ceremonies_preserveSuccessAndTypedFailure() = runTest {
+        val jsonClient = FakeJsonPasskeyClient(
+            create = PasskeyResult.Success("{\"registration\":true}"),
+            get = PasskeyResult.Failure(PasskeyClientError.UserCancelled()),
+        )
+        val bridge = SwiftPasskeyBridge(FakePasskeyClient(), jsonClient)
+
+        val registration = bridge.createCredential("{}")
+        val authentication = bridge.getAssertion("{}")
+
+        assertEquals("{\"registration\":true}", registration.responseJson)
+        assertEquals("userCancelled", authentication.errorCode)
+    }
+
+    @Test
+    fun ceremonies_distinguishConcurrencyFromInternalStateFailures() = runTest {
+        val failingJsonClient = FakeJsonPasskeyClient(
+            create = PasskeyResult.Success("{}"),
+            get = PasskeyResult.Success("{}"),
+            createFailure = IllegalStateException("unrelated internal state"),
+        )
+        val failingBridge = SwiftPasskeyBridge(FakePasskeyClient(), failingJsonClient)
+        val internalFailure = failingBridge.createCredential("{}")
+
+        val nestedBridge = SwiftPasskeyBridge(
+            FakePasskeyClient(),
+            FakeJsonPasskeyClient(
+                create = PasskeyResult.Success("{}"),
+                get = PasskeyResult.Success("{}"),
+            ),
+        )
+        val concurrentFailure = nestedBridge.runExclusive {
+            nestedBridge.createCredential("{}")
+        }
+
+        assertEquals("bridgeContract", internalFailure.errorCode)
+        assertEquals("operationInProgress", concurrentFailure.errorCode)
+    }
+
+    @Test
+    fun ceremonies_neverMapCancellationToADomainFailure() = runTest {
+        val jsonClient = FakeJsonPasskeyClient(
+            create = PasskeyResult.Success("{}"),
+            get = PasskeyResult.Success("{}"),
+            createFailure = CancellationException("cancelled"),
+        )
+        val bridge = SwiftPasskeyBridge(FakePasskeyClient(), jsonClient)
+
+        assertFailsWith<CancellationException> {
+            bridge.createCredential("{}")
+        }
+    }
+
+    @Test
+    fun prfBridge_authenticatesAndReturnsRawOutputs() = runTest {
+        val codec = KotlinxWebAuthnJsonCodec()
+        val prfOutput = Base64UrlBytes.fromBytes(ByteArray(32) { 9 })
+        val passkeyClient = FakePasskeyClient(
+            assertion = PasskeyResult.Success(validAuthenticationResponse(prfOutput)),
+        )
+        val bridge = SwiftPrfBridge(passkeyClient, codec)
+
+        val authentication = bridge.authenticate(
+            requestJson = codec.encodeRequestOptions(validRequestOptions()),
+            firstSaltBase64Url = Base64UrlBytes.fromBytes(ByteArray(32) { 1 }).encoded(),
+            secondSaltBase64Url = null,
+        )
+
+        assertTrue(authentication.isSuccess)
+        assertEquals(prfOutput.encoded(), authentication.firstResultBase64Url)
+        assertEquals(
+            Base64UrlBytes.fromBytes(ByteArray(32) { 1 }),
+            assertNotNull(passkeyClient.lastAssertionOptions).extensions?.prf?.eval?.first,
+        )
+    }
+
+    @Test
+    fun prfBridge_rejectsMalformedInputWithoutPrompting() = runTest {
+        val passkeyClient = FakePasskeyClient()
+        val bridge = SwiftPrfBridge(passkeyClient)
+
+        val result = bridge.authenticate(
+            requestJson = "{not-json",
+            firstSaltBase64Url = "invalid=",
+            secondSaltBase64Url = null,
+        )
+
+        assertEquals("invalidOptions", result.errorCode)
+        assertEquals(0, passkeyClient.assertionCalls)
+    }
+
+    private class FakeJsonPasskeyClient(
+        private val create: PasskeyResult<String>,
+        private val get: PasskeyResult<String>,
+        private val createFailure: Throwable? = null,
+    ) : JsonPasskeyClient {
+        override suspend fun createCredentialJson(requestJson: String): PasskeyResult<String> {
+            createFailure?.let { throw it }
+            return create
+        }
+
+        override suspend fun getAssertionJson(requestJson: String): PasskeyResult<String> = get
+    }
+
+    private class FakePasskeyClient(
+        private val assertion: PasskeyResult<RawAuthenticationResponse> =
+            PasskeyResult.Failure(PasskeyClientError.Platform("unused")),
+    ) : PasskeyClient {
+        var assertionCalls: Int = 0
+        var lastAssertionOptions: PublicKeyCredentialRequestOptions? = null
+
+        override suspend fun createCredential(
+            options: PublicKeyCredentialCreationOptions,
+        ): PasskeyResult<RawRegistrationResponse> =
+            PasskeyResult.Failure(PasskeyClientError.Platform("unused"))
+
+        override suspend fun getAssertion(
+            options: PublicKeyCredentialRequestOptions,
+        ): PasskeyResult<RawAuthenticationResponse> {
+            assertionCalls += 1
+            lastAssertionOptions = options
+            return assertion
+        }
+
+        override suspend fun capabilities(): PasskeyCapabilities = PasskeyCapabilities()
+    }
+
+    private companion object {
+        fun validRequestOptions(): PublicKeyCredentialRequestOptions = PublicKeyCredentialRequestOptions(
+            challenge = Challenge.fromBytes(ByteArray(32) { 2 }),
+            rpId = RpId.parseOrThrow("example.com"),
+        )
+
+        fun validAuthenticationResponse(prfOutput: Base64UrlBytes): RawAuthenticationResponse =
+            RawAuthenticationResponse(
+                credentialId = CredentialId.fromBytes(byteArrayOf(8, 8, 8)),
+                clientDataJson = Base64UrlBytes.fromBytes(byteArrayOf(1, 1, 1)),
+                authenticatorData = Base64UrlBytes.fromBytes(ByteArray(37) { 3 }),
+                signature = Base64UrlBytes.fromBytes(byteArrayOf(5, 5, 5)),
+                extensions = AuthenticationExtensionsClientOutputs(
+                    prf = PrfExtensionOutput(
+                        results = AuthenticationExtensionsPRFValues(first = prfOutput),
+                    ),
+                ),
+            )
+    }
+}

--- a/documentation/example-inventory.md
+++ b/documentation/example-inventory.md
@@ -4,7 +4,7 @@
 This inventory is generated from the inline `doc-example` directives. It records every user-facing fenced
 example, its single source of truth, and its strongest automated or illustrative verification level.
 
-Managed blocks: **135**
+Managed blocks: **136**
 
 | ID | File | Purpose | Language | Audience | Owner | Source of truth | Verification | Exception |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -46,6 +46,7 @@ Managed blocks: **135**
 | client-webauthn-client-platform-readme-mermaid-1 | client/webauthn-client-platform/README.md:52 | How it fits | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
 | client-webauthn-client-prf-crypto-readme-mermaid-1 | client/webauthn-client-prf-crypto/README.md:14 | What it provides | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
 | client-webauthn-client-prf-crypto-readme-kotlin-1 | client/webauthn-client-prf-crypto/README.md:36 | How to use | kotlin | consumer | source | documentation/examples/src/commonMain/kotlin/dev/webauthn/documentation/examples/PrfCryptoExample.kt#prf-crypto | compile |  |
+| client-webauthn-client-swift-bridge-readme-bash-1 | client/webauthn-client-swift-bridge/README.md:26 | webauthn-client-swift-bridge | bash | contributor | markdown | Markdown block | syntax |  |
 | core-webauthn-cbor-core-readme-mermaid-1 | core/webauthn-cbor-core/README.md:17 | How it fits in the system | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
 | core-webauthn-core-readme-mermaid-1 | core/webauthn-core/README.md:15 | What it provides | mermaid | consumer | illustrative | Markdown illustration | illustrative | Diagram is rendered by the Markdown host |
 | core-webauthn-core-readme-kotlin-1 | core/webauthn-core/README.md:35 | How to use | kotlin | consumer | source | documentation/examples/src/commonMain/kotlin/dev/webauthn/documentation/examples/CoreValidationExample.kt#core-validation | compile |  |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ androidx-test-ext-junit = "1.3.0"
 androidx-test-core = "1.7.0"
 signum = "0.16.0"
 signum-indispensable = "3.26.0"
+skie = "0.10.14"
 kermit = "2.1.0"
 exposed = "1.5.0"
 testcontainers = "1.21.4"
@@ -124,3 +125,4 @@ compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose-m
 binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "bcv" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 detekt = { id = "dev.detekt", version.ref = "detekt" }
+skie = { id = "co.touchlab.skie", version.ref = "skie" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -45,6 +45,7 @@ include(
     ":client:webauthn-client-json-core",
     ":client:webauthn-client-compose",
     ":client:webauthn-client-platform",
+    ":client:webauthn-client-swift-bridge",
     ":sample:backend-ktor",
     ":sample:android-passkey",
     ":sample:ios-passkey",

--- a/swift/Resources/PrivacyInfo.xcprivacy
+++ b/swift/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+</dict>
+</plist>

--- a/swift/THIRD_PARTY_NOTICES.txt
+++ b/swift/THIRD_PARTY_NOTICES.txt
@@ -1,0 +1,29 @@
+WebAuthn Swift SDK third-party notices
+======================================
+
+The WebAuthnBridge static framework contains code from the components listed
+below. Versions reflect the resolved iOS release compile graph for this
+distribution.
+
+Apache License 2.0 components
+-----------------------------
+
+The Apache License 2.0 text is distributed as LICENSE next to this file.
+
+- Kotlin and the Kotlin/Native runtime 2.4.10
+  https://github.com/JetBrains/kotlin
+- SKIE runtime 0.10.14
+  https://github.com/touchlab/SKIE
+- KMMResult 1.9.3
+  https://github.com/a-sit-plus/KmmResult
+- kotlinx.coroutines 1.11.0
+  https://github.com/Kotlin/kotlinx.coroutines
+- kotlinx.atomicfu 0.32.1
+  https://github.com/Kotlin/kotlinx-atomicfu
+- kotlinx.serialization 1.11.0
+  https://github.com/Kotlin/kotlinx.serialization
+
+The Kotlin compiler distribution provides the following notice:
+
+  Kotlin Compiler
+  Copyright 2010-2024 JetBrains s.r.o and respective authors and developers

--- a/tools/swift/check-xcframework.sh
+++ b/tools/swift/check-xcframework.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+xcframework="${1:-$repo_root/client/webauthn-client-swift-bridge/build/XCFrameworks/release/WebAuthnBridge.xcframework}"
+if [[ ! -d "$xcframework" ]]; then
+  echo "Missing XCFramework: $xcframework" >&2
+  exit 1
+fi
+deployment_scan="$(mktemp -d "${TMPDIR:-/tmp}/webauthn-xcframework-minos.XXXXXX")"
+trap 'rm -rf "$deployment_scan"' EXIT
+
+python3 - "$xcframework/Info.plist" <<'PY'
+import plistlib
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+with path.open("rb") as source:
+    info = plistlib.load(source)
+actual = {
+    (
+        item["LibraryIdentifier"],
+        tuple(item["SupportedArchitectures"]),
+        item["SupportedPlatform"],
+        item.get("SupportedPlatformVariant"),
+    )
+    for item in info["AvailableLibraries"]
+}
+expected = {
+    ("ios-arm64", ("arm64",), "ios", None),
+    ("ios-arm64-simulator", ("arm64",), "ios", "simulator"),
+}
+if actual != expected:
+    raise SystemExit(f"Unexpected XCFramework slices: {sorted(actual)}")
+
+for framework_info in path.parent.glob("*/WebAuthnBridge.framework/Info.plist"):
+    with framework_info.open("rb") as source:
+        framework = plistlib.load(source)
+    if framework.get("CFBundleIdentifier") != "dev.webauthn.swift.bridge":
+        raise SystemExit(f"Unexpected framework bundle identifier: {framework_info}")
+    version = framework.get("CFBundleShortVersionString", "")
+    if re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", version) is None:
+        raise SystemExit(f"Invalid framework bundle version {version!r}: {framework_info}")
+PY
+
+for slice in ios-arm64 ios-arm64-simulator; do
+  framework="$xcframework/$slice/WebAuthnBridge.framework"
+  binary="$framework/WebAuthnBridge"
+  manifest="$framework/PrivacyInfo.xcprivacy"
+  license="$framework/LICENSE"
+  notices="$framework/THIRD_PARTY_NOTICES.txt"
+  [[ -f "$binary" ]] || { echo "Missing framework binary: $binary" >&2; exit 1; }
+  [[ -s "$license" ]] || { echo "Missing framework license: $license" >&2; exit 1; }
+  [[ -s "$notices" ]] || { echo "Missing framework third-party notices: $notices" >&2; exit 1; }
+  cmp -s "$repo_root/LICENSE" "$license" || {
+    echo "Framework license does not match the repository license: $license" >&2
+    exit 1
+  }
+  cmp -s "$repo_root/swift/THIRD_PARTY_NOTICES.txt" "$notices" || {
+    echo "Framework third-party notices are stale: $notices" >&2
+    exit 1
+  }
+  [[ "$(lipo -archs "$binary")" == "arm64" ]] || {
+    echo "Unexpected architecture in $binary: $(lipo -archs "$binary")" >&2
+    exit 1
+  }
+  file "$binary" | grep 'current ar archive' >/dev/null || {
+    echo "Expected a static framework archive: $binary" >&2
+    exit 1
+  }
+  slice_scan="$deployment_scan/$slice"
+  mkdir -p "$slice_scan"
+  (cd "$slice_scan" && ar -x "$binary")
+  while IFS= read -r -d '' object; do
+    min_os="$(xcrun vtool -show-build "$object" 2>/dev/null | awk '/^[[:space:]]+minos / {print $2; exit}')"
+    [[ -z "$min_os" ]] && continue
+    python3 - "$min_os" "$object" <<'PY'
+import sys
+
+parts = [int(part) for part in sys.argv[1].split(".")]
+version = tuple((parts + [0, 0, 0])[:3])
+if version > (16, 0, 0):
+    raise SystemExit(f"Object requires iOS {sys.argv[1]}, above package minimum: {sys.argv[2]}")
+PY
+  done < <(find "$slice_scan" -type f -name '*.o' -print0)
+  plutil -lint "$manifest" >/dev/null
+  if grep -a -q '/Users/' "$binary"; then
+    echo "Build-machine path found in release binary: $binary" >&2
+    exit 1
+  fi
+  if nm -u "$binary" 2>/dev/null | grep -E '(^|[[:space:]])(_mach_absolute_time|_stat|_fstat|_lstat|_statfs|_fstatfs|_getattrlist|_getattrlistbulk|_fgetattrlist|_CFPreferencesCopyAppValue|_OBJC_CLASS_\$_NSUserDefaults)$' >/dev/null; then
+    echo "A required-reason API appeared; review and update PrivacyInfo.xcprivacy before release." >&2
+    exit 1
+  fi
+done
+
+python3 - "$xcframework" <<'PY'
+import plistlib
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+for manifest in root.glob("*/WebAuthnBridge.framework/PrivacyInfo.xcprivacy"):
+    with manifest.open("rb") as source:
+        data = plistlib.load(source)
+    expected = {
+        "NSPrivacyAccessedAPITypes": [],
+        "NSPrivacyCollectedDataTypes": [],
+        "NSPrivacyTracking": False,
+        "NSPrivacyTrackingDomains": [],
+    }
+    if data != expected:
+        raise SystemExit(f"Unexpected privacy manifest contents: {manifest}")
+PY
+
+while IFS= read -r -d '' interface; do
+  if grep -n '/Users/' "$interface"; then
+    echo "Build-machine path found in a Swift interface: $interface" >&2
+    exit 1
+  fi
+done < <(find "$xcframework" -type f -name '*.swiftinterface' -print0)
+
+swift_smoke="$deployment_scan/BridgeLinkSmoke.swift"
+cat > "$swift_smoke" <<'SWIFT'
+import WebAuthnBridge
+
+@main
+struct BridgeLinkSmoke {
+    static func main() {
+        _ = SwiftPasskeyBridge()
+    }
+}
+SWIFT
+simulator_sdk="$(xcrun --sdk iphonesimulator --show-sdk-path)"
+xcrun --sdk iphonesimulator swiftc \
+  -target arm64-apple-ios16.0-simulator \
+  -sdk "$simulator_sdk" \
+  -F "$xcframework/ios-arm64-simulator" \
+  -framework WebAuthnBridge \
+  -parse-as-library \
+  -o "$deployment_scan/BridgeLinkSmoke" \
+  "$swift_smoke"
+
+echo "XCFramework structure, metadata, path hygiene, and Swift import/link checks passed."

--- a/tools/swift/postprocess-xcframework.sh
+++ b/tools/swift/postprocess-xcframework.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+  echo "Usage: $0 <xcframework-path> <privacy-manifest-path> <license-path> <notices-path>" >&2
+  exit 2
+fi
+
+xcframework="$1"
+privacy_manifest="$2"
+project_license="$3"
+third_party_notices="$4"
+if [[ ! -d "$xcframework" || ! -f "$privacy_manifest" || ! -f "$project_license" || ! -f "$third_party_notices" ]]; then
+  echo "XCFramework post-processing input is missing." >&2
+  exit 1
+fi
+
+framework_count=0
+for framework in "$xcframework"/*/WebAuthnBridge.framework; do
+  [[ -d "$framework" ]] || continue
+  framework_count=$((framework_count + 1))
+  cp "$privacy_manifest" "$framework/PrivacyInfo.xcprivacy"
+  cp "$project_license" "$framework/LICENSE"
+  cp "$third_party_notices" "$framework/THIRD_PARTY_NOTICES.txt"
+  xcrun strip -S "$framework/WebAuthnBridge"
+done
+if [[ $framework_count -eq 0 ]]; then
+  echo "No WebAuthnBridge.framework slices found in $xcframework" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- add a dedicated Kotlin/Native bridge with stable primitive results, error codes, capabilities, and exclusive ceremony execution
- build a distributable static XCFramework for arm64 iOS devices and Apple Silicon simulators
- embed privacy and third-party notices, normalize bundle metadata, strip build-path metadata, and validate every framework slice
- add an explicit KLIB API baseline and exhaustive bridge tests

## Validation

- `tools/agent/quality-gate.sh --mode strict --scope full --block true`
- `./gradlew apiCheck --stacktrace`
- bridge iOS simulator tests and XCFramework assembly
- XCFramework architecture, static-linkage, metadata, symbol, and deployment-target checks

## Stack

- **#268 — PR 1 of 5: this PR**
- #269
- #270
- #271
- #272


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an iOS Swift bridge for creating passkeys, retrieving assertions, checking capabilities, and performing PRF authentication.
  * Added structured success and error results for Swift integrations.
  * Added XCFramework distribution for supported iOS targets.

* **Documentation**
  * Added integration and distribution guidance for native Swift consumers.

* **Chores**
  * Added privacy metadata, licensing notices, and release validation for the XCFramework.
  * Added Python cache exclusions to repository configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->