### PR TITLE
ci(swift): automate validation and release packaging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,12 +11,27 @@ on:
         options:
           - publish-only
           - publish-and-release
+          - finalize-release
       version_name:
-        description: "Optional VERSION_NAME override (for example x.y.z)"
+        description: "Optional VERSION_NAME override (required for finalize-release)"
+        required: false
+        type: string
+      swift_device_qualified:
+        description: "A physical iPhone passed the documented Swift release qualification"
+        required: true
+        default: false
+        type: boolean
+      swift_device_qualification_evidence:
+        description: "HTTPS URL of the recorded physical-iPhone evidence for this exact source commit"
+        required: false
+        type: string
+      recovery_run_id:
+        description: "Original publish workflow run ID (required for finalize-release)"
         required: false
         type: string
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -28,8 +43,11 @@ jobs:
     if: github.ref == 'refs/heads/main'
     outputs:
       resolved_version: ${{ steps.resolve_version.outputs.resolved_version }}
-    runs-on: macos-latest
-    timeout-minutes: 45
+    runs-on: macos-26
+    timeout-minutes: 75
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
+      WEBAUTHN_EXPECTED_XCODE_VERSION: '26.6'
     steps:
       - uses: actions/checkout@v7
         with:
@@ -40,99 +58,202 @@ jobs:
           java-version: '21'
       - uses: gradle/actions/setup-gradle@v6
 
+      - name: Assert release Xcode
+        run: |
+          ACTUAL_XCODE_VERSION="$(xcodebuild -version | awk 'NR == 1 { print $2 }')"
+          test "$ACTUAL_XCODE_VERSION" = "$WEBAUTHN_EXPECTED_XCODE_VERSION" || {
+            echo "Expected Xcode $WEBAUTHN_EXPECTED_XCODE_VERSION, found $ACTUAL_XCODE_VERSION."
+            exit 1
+          }
+
+      - name: Resolve and guard release inputs
+        id: resolve_version
+        env:
+          VERSION_NAME_INPUT: ${{ inputs.version_name }}
+          RELEASE_MODE_INPUT: ${{ inputs.release_mode }}
+          SWIFT_DEVICE_QUALIFIED: ${{ inputs.swift_device_qualified }}
+          SWIFT_DEVICE_QUALIFICATION_EVIDENCE: ${{ inputs.swift_device_qualification_evidence }}
+          RECOVERY_RUN_ID: ${{ inputs.recovery_run_id }}
+        run: |
+          RESOLVED_VERSION="$VERSION_NAME_INPUT"
+          if [ -z "$RESOLVED_VERSION" ]; then
+            RESOLVED_VERSION="$(sed -n 's/^VERSION_NAME=//p' gradle.properties | head -n 1)"
+          fi
+          test -n "$RESOLVED_VERSION" || {
+            echo "Unable to resolve VERSION_NAME."
+            exit 1
+          }
+          if [ "$RELEASE_MODE_INPUT" != "publish-only" ] && [[ "$RESOLVED_VERSION" == *SNAPSHOT* ]]; then
+            echo "Refusing a Swift release for snapshot version: $RESOLVED_VERSION"
+            exit 1
+          fi
+          if [ "$RELEASE_MODE_INPUT" = "publish-and-release" ] && [ "$SWIFT_DEVICE_QUALIFIED" != "true" ]; then
+            echo "Physical iPhone qualification is required for a Swift release."
+            exit 1
+          fi
+          if [ "$RELEASE_MODE_INPUT" = "publish-and-release" ] && [[ ! "$SWIFT_DEVICE_QUALIFICATION_EVIDENCE" =~ ^https://[^[:space:]]+$ ]]; then
+            echo "publish-and-release requires an HTTPS physical-device qualification evidence URL."
+            exit 1
+          fi
+          if [ "$RELEASE_MODE_INPUT" = "finalize-release" ]; then
+            test -n "$VERSION_NAME_INPUT" || {
+              echo "finalize-release requires an explicit version_name."
+              exit 1
+            }
+            [[ "$RECOVERY_RUN_ID" =~ ^[0-9]+$ ]] || {
+              echo "finalize-release requires the numeric run ID that produced the original artifacts."
+              exit 1
+            }
+          elif [ -n "$RECOVERY_RUN_ID" ]; then
+            echo "recovery_run_id is valid only with finalize-release."
+            exit 1
+          fi
+          echo "Resolved VERSION_NAME=$RESOLVED_VERSION"
+          echo "resolved_version=$RESOLVED_VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Validate Maven Central secrets
+        if: ${{ inputs.release_mode != 'finalize-release' }}
         env:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
         run: |
-          test -n "$MAVEN_CENTRAL_USERNAME" || (echo "Missing secret: MAVEN_CENTRAL_USERNAME" && exit 1)
-          test -n "$MAVEN_CENTRAL_PASSWORD" || (echo "Missing secret: MAVEN_CENTRAL_PASSWORD" && exit 1)
-          test -n "$SIGNING_KEY" || (echo "Missing secret: SIGNING_KEY" && exit 1)
-          test -n "$SIGNING_KEY_PASSWORD" || (echo "Missing secret: SIGNING_KEY_PASSWORD" && exit 1)
+          test -n "$MAVEN_CENTRAL_USERNAME" || { echo "Missing secret: MAVEN_CENTRAL_USERNAME"; exit 1; }
+          test -n "$MAVEN_CENTRAL_PASSWORD" || { echo "Missing secret: MAVEN_CENTRAL_PASSWORD"; exit 1; }
+          test -n "$SIGNING_KEY" || { echo "Missing secret: SIGNING_KEY"; exit 1; }
+          test -n "$SIGNING_KEY_PASSWORD" || { echo "Missing secret: SIGNING_KEY_PASSWORD"; exit 1; }
 
-      - name: Guard release mode against snapshot versions
-        id: resolve_version
-        env:
-          VERSION_NAME_INPUT: ${{ inputs.version_name }}
-          RELEASE_MODE_INPUT: ${{ inputs.release_mode }}
-        run: |
-          RESOLVED_VERSION="$VERSION_NAME_INPUT"
-          if [ -z "$RESOLVED_VERSION" ]; then
-            RESOLVED_VERSION="$(sed -n 's/^VERSION_NAME=//p' gradle.properties | head -n 1)"
-          fi
-
-          test -n "$RESOLVED_VERSION" || (echo "Unable to resolve VERSION_NAME" && exit 1)
-          echo "Resolved VERSION_NAME=$RESOLVED_VERSION"
-          echo "resolved_version=$RESOLVED_VERSION" >> "$GITHUB_OUTPUT"
-
-          if [ "$RELEASE_MODE_INPUT" = "publish-and-release" ] && [[ "$RESOLVED_VERSION" == *SNAPSHOT* ]]; then
-            echo "Refusing publish-and-release for SNAPSHOT version: $RESOLVED_VERSION"
-            exit 1
-          fi
-
-      - name: Validate curated release notes
+      - name: Prepare all Swift release inputs
         if: ${{ inputs.release_mode == 'publish-and-release' }}
         env:
           RELEASE_VERSION: ${{ steps.resolve_version.outputs.resolved_version }}
+          SWIFT_DEVICE_QUALIFICATION_EVIDENCE: ${{ inputs.swift_device_qualification_evidence }}
         run: |
+          SWIFT_RELEASE_DIR="$RUNNER_TEMP/swift-release"
+          mkdir -p "$SWIFT_RELEASE_DIR"
           bash tools/agent/extract-release-notes.sh \
             "$RELEASE_VERSION" \
             CHANGELOG.md \
-            "$RUNNER_TEMP/release-notes.md"
+            "$SWIFT_RELEASE_DIR/release-notes.md"
+          tools/swift/prepare-release.sh "$RELEASE_VERSION" "$SWIFT_RELEASE_DIR"
+          jq -n \
+            --arg version "$RELEASE_VERSION" \
+            --arg sourceCommit "$GITHUB_SHA" \
+            --arg qualificationEvidence "$SWIFT_DEVICE_QUALIFICATION_EVIDENCE" \
+            --arg releaseWorkflowRun "https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            '{schemaVersion: 1, version: $version, sourceCommit: $sourceCommit, physicalDeviceQualified: true, qualificationEvidence: $qualificationEvidence, releaseWorkflowRun: $releaseWorkflowRun}' \
+            > "$SWIFT_RELEASE_DIR/release-metadata.json"
+          python3 tools/swift/reconcile_release.py --validate-only "$SWIFT_RELEASE_DIR"
+
+      - name: Restore original Swift release inputs
+        if: ${{ inputs.release_mode == 'finalize-release' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: swift-package-release
+          path: ${{ runner.temp }}/swift-release
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.recovery_run_id }}
+
+      - name: Validate recovered Swift release inputs
+        if: ${{ inputs.release_mode == 'finalize-release' }}
+        env:
+          RELEASE_VERSION: ${{ steps.resolve_version.outputs.resolved_version }}
+        run: |
+          python3 tools/swift/reconcile_release.py --validate-only "$RUNNER_TEMP/swift-release"
+          test "$(jq -r .version "$RUNNER_TEMP/swift-release/release-metadata.json")" = "$RELEASE_VERSION" || {
+            echo "Recovered artifacts belong to another version."
+            exit 1
+          }
+
+      - name: Preflight empty GitHub release target
+        if: ${{ inputs.release_mode == 'publish-and-release' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 tools/swift/reconcile_release.py \
+            --require-empty \
+            --repository "$GITHUB_REPOSITORY" \
+            "$RUNNER_TEMP/swift-release"
+
+      - name: Retain exact Swift release inputs for recovery
+        if: ${{ inputs.release_mode != 'publish-only' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: swift-package-release
+          if-no-files-found: error
+          retention-days: 30
+          path: |
+            ${{ runner.temp }}/swift-release/Package.swift
+            ${{ runner.temp }}/swift-release/WebAuthnBridge.xcframework.zip
+            ${{ runner.temp }}/swift-release/WebAuthnBridge.xcframework.zip.sha256
+            ${{ runner.temp }}/swift-release/release-notes.md
+            ${{ runner.temp }}/swift-release/release-metadata.json
+
+      - name: Build and verify Maven publication locally
+        if: ${{ inputs.release_mode != 'finalize-release' }}
+        env:
+          RELEASE_VERSION: ${{ steps.resolve_version.outputs.resolved_version }}
+          VERSION_NAME_OVERRIDE: ${{ steps.resolve_version.outputs.resolved_version }}
+        run: |
+          ./gradlew publishToMavenLocal \
+            -PVERSION_NAME="$RELEASE_VERSION" \
+            -PsignAllPublications=false \
+            --stacktrace
+          bash tools/agent/check-published-consumer-smoke.sh
 
       - name: Publish to Maven Central
+        if: ${{ inputs.release_mode != 'finalize-release' }}
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
-          VERSION_NAME_INPUT: ${{ inputs.version_name }}
+          RELEASE_VERSION: ${{ steps.resolve_version.outputs.resolved_version }}
           RELEASE_MODE_INPUT: ${{ inputs.release_mode }}
         run: |
-          VERSION_ARG=""
-          if [ -n "$VERSION_NAME_INPUT" ]; then
-            VERSION_ARG="-PVERSION_NAME=$VERSION_NAME_INPUT"
-          fi
-
           if [ "$RELEASE_MODE_INPUT" = "publish-and-release" ]; then
-            ./gradlew publishAndReleaseToMavenCentral --no-daemon ${VERSION_ARG:+"$VERSION_ARG"}
+            ./gradlew publishAndReleaseToMavenCentral \
+              --no-daemon \
+              -PVERSION_NAME="$RELEASE_VERSION"
           else
-            ./gradlew publishToMavenCentral --no-daemon ${VERSION_ARG:+"$VERSION_ARG"}
+            ./gradlew publishToMavenCentral \
+              --no-daemon \
+              -PVERSION_NAME="$RELEASE_VERSION"
           fi
 
   github-release:
-    if: ${{ inputs.release_mode == 'publish-and-release' }}
+    if: ${{ inputs.release_mode != 'publish-only' }}
     needs: [publish]
     permissions:
+      actions: read
       contents: write
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    runs-on: macos-26
+    timeout-minutes: 45
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
+      WEBAUTHN_EXPECTED_XCODE_VERSION: '26.6'
     steps:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - name: Extract curated release notes
-        env:
-          RELEASE_VERSION: ${{ needs.publish.outputs.resolved_version }}
+      - uses: actions/download-artifact@v8
+        with:
+          name: swift-package-release
+          path: ${{ runner.temp }}/swift-release
+      - name: Install pinned XcodeGen
         run: |
-          bash tools/agent/extract-release-notes.sh \
-            "$RELEASE_VERSION" \
-            CHANGELOG.md \
-            "$RUNNER_TEMP/release-notes.md"
-      - name: Create GitHub release
+          tools/swift/install-xcodegen.sh "$RUNNER_TEMP/xcodegen"
+          echo "$RUNNER_TEMP/xcodegen/xcodegen/bin" >> "$GITHUB_PATH"
+      - name: Reconcile and verify GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: v${{ needs.publish.outputs.resolved_version }}
         run: |
-          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            echo "Release $RELEASE_TAG already exists; skipping."
-            exit 0
-          fi
-
-          gh release create "$RELEASE_TAG" \
-            --target "$GITHUB_SHA" \
-            --title "$RELEASE_TAG" \
-            --notes-file "$RUNNER_TEMP/release-notes.md"
+          python3 tools/swift/reconcile_release.py \
+            --repository "$GITHUB_REPOSITORY" \
+            "$RUNNER_TEMP/swift-release"
+      - name: Clean external Swift package consumer smoke
+        env:
+          RELEASE_VERSION: ${{ needs.publish.outputs.resolved_version }}
+        run: tools/swift/check-release-consumer.sh "$RELEASE_VERSION"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,8 +36,10 @@ When reporting, include affected module(s), threat model assumptions, and whethe
 - Java/Kotlin CodeQL scanning is temporarily disabled while the current CodeQL CLI toolchain does not support Kotlin `2.3.10`.
 - Dependency risk is enforced on pull requests via `actions/dependency-review-action`.
 - CI checkout steps disable persisted Git credentials before Gradle executes repository code.
+- The Swift CI job has read-only repository access and validates the static XCFramework's slices, privacy
+  manifest, required-reason API boundary, build-path hygiene, public API baseline, and Kotlin/Swift semantic parity.
 - The privileged Diff Breakdown workflow pins executable action code to a full commit SHA and loads data-only configuration from the exact pull-request base commit. It never checks out or executes a pull-request head; untrusted pull-request content is consumed only as GitHub API metadata, with `contents: read` and `pull-requests: write` permissions.
 - Renovate manages dependency and GitHub Actions updates.
 - The sample backend defaults to strict attestation verification; use `WEBAUTHN_SAMPLE_ATTESTATION=NONE` only as an explicit local-development override.
 - Maven Central publication is a manual workflow and requires signing plus Central Portal credentials.
-- The Central publishing job runs with read-only repository contents and disables persisted Git credentials before executing Gradle. A separate `publish-and-release`-only job receives `contents:write` solely to create the matching GitHub release tag from curated changelog notes.
+- The Central publishing job runs with read-only repository contents and disables persisted Git credentials before executing Gradle. A separate GitHub-release job receives `contents:write` only after Central succeeds or during explicit finalization recovery. It creates or verifies a detached release commit whose only tree change is the checksum-pinned Swift package manifest, reconciles the coordinated tag/release from immutable retained inputs, reads back exact assets, repairs only missing expected assets, and rejects conflicting or extra release state.

--- a/docs/MAVEN_CENTRAL.md
+++ b/docs/MAVEN_CENTRAL.md
@@ -2,6 +2,9 @@
 
 This repository publishes with `com.vanniktech.maven.publish` to Sonatype Central Portal.
 
+The same manual release train can also publish the native Swift package as a checksum-pinned XCFramework
+asset. Maven coordinates and the Swift package use one resolved version.
+
 ## Coordinates
 
 - Group: `io.github.szijpeter`
@@ -85,23 +88,49 @@ Inputs:
 
 - `release_mode=publish-only`
 - `release_mode=publish-and-release`
+- `release_mode=finalize-release` with the original workflow run ID after Central succeeded but GitHub finalization did not
 - optional `version_name=x.y.z`
+- `swift_device_qualified=true` and `swift_device_qualification_evidence=https://...` for `publish-and-release`
 
 Guardrails:
 
-- `publish-and-release` is blocked for snapshot versions.
+- `publish-and-release` is blocked for snapshot versions and requires both the documented physical-iPhone qualification checkbox and a stable HTTPS evidence URL for the exact source commit.
 - `publish-and-release` requires a matching versioned `CHANGELOG.md` section and creates the GitHub release/tag (`vX.Y.Z`) from those curated notes after successful Central publication.
-- The Central job has read-only repository contents and no persisted Git credentials; only the separate GitHub-release job receives `contents:write`.
+- `publish-and-release` also builds and inspects the static Swift XCFramework, uploads it with its SHA-256 checksum, and tags a generated manifest whose binary-target URL and checksum point to that exact release asset.
+- `publish-only` publishes Maven artifacts only; it intentionally creates neither a GitHub release nor a Swift package release.
+- All Maven and Swift artifacts are built and checked before Central publication. The exact Swift manifest, archive, checksum, notes, source commit, and qualification metadata are retained together as an immutable workflow artifact for 30 days.
+- The Central job has read-only repository contents and no persisted Git credentials; only the separate GitHub-release job receives `contents:write` after Central succeeds or during explicit finalization recovery.
+- A new `publish-and-release` run requires an empty tag/release target. The privileged job creates a draft, uploads and reads back exact assets, then publishes it. Existing state is accepted only by `finalize-release` when the tag parent, manifest bytes, title, notes, and assets match the original retained inputs. Missing expected assets are repaired; conflicting or extra state is rejected without replacement or deletion.
+- The generated commit is exactly one commit above the released `main` SHA and changes only `Package.swift`; it is reachable through the release tag, not pushed to `main`.
+- `finalize-release` never republishes Maven artifacts. It requires the exact version and original workflow run ID, restores that run's immutable Swift inputs, and safely resumes or verifies GitHub release finalization.
 - Publishing remains manual; merges to `main` do not auto-publish.
+
+## Swift Artifact Dry Run
+
+Prepare the exact release inputs without publishing:
+
+<!-- doc-example: id=docs-maven-central-bash-2; owner=markdown; verify=syntax; audience=maintainer -->
+```bash
+VERSION=0.4.1
+OUTPUT_DIRECTORY=/path/to/output
+tools/swift/prepare-release.sh "$VERSION" "$OUTPUT_DIRECTORY"
+```
+
+Review the XCFramework archive, checksum, and generated `Package.swift`. The release archive supports arm64
+iOS devices and arm64 simulators; `iosX64` is intentionally absent. The root manifest remains local-path based
+for repository development, while versioned tags contain the remote checksum-pinned manifest.
 
 ## Release Runbook
 
 1. Ensure PR CI is green, including `apiCheck`, `publishToMavenLocal` preflight, and `check-published-consumer-smoke`.
 2. Set `VERSION_NAME=x.y.z` or pass `version_name` to the workflow.
-3. Trigger the `Publish` workflow with `release_mode=publish-and-release`.
-4. Verify Central Portal status and artifact resolution.
-5. Verify GitHub release/tag `vX.Y.Z` exists (auto-created by `publish-and-release`).
-6. Move `main` back to the next snapshot version.
+3. Complete and record the physical-iPhone checks in `PUBLIC_LAUNCH_CHECKLIST.md` for the exact release commit.
+4. Trigger the `Publish` workflow with `release_mode=publish-and-release`, `swift_device_qualified=true`, and the recorded `swift_device_qualification_evidence` URL.
+5. Verify Central Portal status and artifact resolution.
+6. Verify GitHub release/tag `vX.Y.Z` exists with both Swift assets and that the external-consumer smoke passed.
+7. Confirm the release tag's `Package.swift` references the same version and SHA-256 value as the downloaded asset.
+8. If Central succeeded but finalization failed, rerun with `release_mode=finalize-release`, the same explicit version, and the original run ID; do not rerun Central publication.
+9. Move `main` back to the next snapshot version.
 
 ## Current State
 

--- a/docs/PUBLIC_LAUNCH_CHECKLIST.md
+++ b/docs/PUBLIC_LAUNCH_CHECKLIST.md
@@ -7,7 +7,7 @@ Use this checklist when moving from private to public operation.
 1. Security policy file exists and is current: `SECURITY.md`.
 2. CI workflows use least-privilege `permissions`, explicit versioned action references, and
    `persist-credentials: false` on every checkout before repository code executes.
-   - Central publication runs with read-only repository contents and no persisted Git credentials; a separate `publish-and-release`-only job requires `contents:write` solely to create the release tag from curated changelog notes.
+   - Central publication runs with read-only repository contents and no persisted Git credentials; a separate GitHub-release job receives `contents:write` only after Central succeeds (or during an explicit `finalize-release` recovery) to create or reconcile the detached Swift package-manifest commit, coordinated release tag, curated GitHub release, and checksum-verified XCFramework assets.
    - Any privileged `pull_request_target` workflow loads executable code only from trusted, explicitly versioned references. Data-only configuration may come from the trusted default branch or the exact pull-request base commit, never the pull-request head; pull-request content is treated as API metadata only.
 3. Dependency automation exists and is current: `.github/renovate.json`.
 4. Local/sensitive files are ignored (`.env*`, `local.properties`, build outputs, IDE state).
@@ -19,8 +19,16 @@ Use this checklist when moving from private to public operation.
    - `./gradlew apiCheck --stacktrace`
    - `./gradlew publishToMavenLocal --stacktrace`
    - `bash tools/agent/check-published-consumer-smoke.sh`
-6. Demo/sample runtime security defaults are explicit (sample backend attestation mode defaults to `STRICT`; relaxed `NONE` mode is opt-in only).
-7. If a temporary release execution-map doc is active, keep it current with scope/sequence changes.
+   - `tools/swift/ci-check.sh` on macOS when the Swift facade, bridge, sample, or release packaging changes
+   - `tools/swift/prepare-release.sh <version> <output-directory>` as a non-publishing artifact dry run before a coordinated release
+6. Before setting `swift_device_qualified=true`, record a physical-iPhone qualification against the exact release commit and a production-like HTTPS relying party:
+   - signed app entitlements contain the expected `webcredentials:` associated domain and the live AASA response authorizes the app identifier;
+   - registration and authentication complete successfully, cancellation maps to the documented cancellation error, and a representative backend rejection remains distinct from platform failure;
+   - PRF authentication establishes a session, encrypt/decrypt round-trips, clearing the session prevents later use, and surfaced UI/log diagnostics contain no salt, PRF output, derived key, user handle, or key fingerprint;
+   - evidence records the commit, device model, iOS version, Xcode version, app identifier, relying-party ID, backend origin, AASA response, and pass/fail result without retaining credentials or secrets.
+   - retain that record at a stable HTTPS URL and pass it as `swift_device_qualification_evidence`; the release metadata preserves the reference beside the exact source commit and immutable release inputs.
+7. Demo/sample runtime security defaults are explicit (sample backend attestation mode defaults to `STRICT`; relaxed `NONE` mode is opt-in only).
+8. If a temporary release execution-map doc is active, keep it current with scope/sequence changes.
 
 ## GitHub Repository Settings
 
@@ -39,6 +47,7 @@ Use this checklist when moving from private to public operation.
 7. Enable private vulnerability reporting.
 8. Confirm GitHub Actions repository settings are least privilege.
 9. Configure Maven Central and signing secrets before attempting a live publish.
+10. Require the blocking Swift CI check in the branch ruleset before publishing the native Swift package.
 
 ## Post-Launch Verification
 
@@ -46,5 +55,8 @@ Use this checklist when moving from private to public operation.
 2. Renovate creates update PRs for Gradle and GitHub Actions.
 3. `SECURITY.md` appears in repository security surfaces.
 4. Maven Central artifacts resolve using the published coordinates and BOM.
-5. No secret findings exist in baseline scans; if any are found, rotate credentials immediately and evaluate targeted history rewrite.
-6. Delete any temporary release execution-map doc once that release effort is complete.
+5. The release workflow's clean external iOS consumer resolves the exact version and compiles the `WebAuthn` product after publication.
+6. The release tag is exactly one manifest-only commit above the recorded source commit; its `Package.swift` bytes and checksum match the retained workflow artifact and downloaded XCFramework.
+7. The GitHub release contains exactly `WebAuthnBridge.xcframework.zip` and its SHA-256 file, while `main` retains the local-development package manifest.
+8. No secret findings exist in baseline scans; if any are found, rotate credentials immediately and evaluate targeted history rewrite.
+9. Delete any temporary release execution-map doc once that release effort is complete.

--- a/docs/ai/STEERING.md
+++ b/docs/ai/STEERING.md
@@ -28,6 +28,7 @@ Build the most robust and standards-first WebAuthn Kotlin Multiplatform library,
 4. If only docs, samples, internal modules, or build logic change, a Maven Central release is not required.
 5. GitHub release tags follow the coordinated version, for example `v0.1.0`.
 6. For major release initiatives, maintain a temporary execution-map doc under `docs/ai/`, keep it updated when decisions drift, and delete it once the effort is complete.
+7. `publish-and-release` publishes the native Swift package at the same version through a checksum-pinned XCFramework asset and release-tag manifest; `publish-only` remains Maven-only, and `finalize-release` may only resume GitHub finalization from the original immutable workflow artifact after Central already succeeded.
 
 ## Published Artifact Surface
 
@@ -62,6 +63,13 @@ Not published:
 - `platform:constraints`
 - `sample:*`
 - `build-logic`
+
+Swift distribution:
+
+- `WebAuthn` is a source facade released from versioned repository tags.
+- `webauthn-client-swift-bridge` is an internal static XCFramework and is never a direct consumer API.
+- `main` keeps a local-path development manifest; the release workflow creates or exactly reconciles a detached tag commit with the remote URL and checksum.
+- A Swift release requires recorded physical-iPhone qualification for the exact source commit and retains its prepared manifest, artifact, checksum, notes, and source metadata for recovery.
 
 ## Crypto Backend Policy
 
@@ -182,6 +190,7 @@ A change is done only when all apply:
 7. Documentation trace policy is satisfied for impacted public API/integration surface (`README.md`, affected module READMEs, and `docs/architecture.md` when public integration paths change).
 8. If CI/security posture changed, `SECURITY.md` and `docs/PUBLIC_LAUNCH_CHECKLIST.md` are updated in the same change.
 9. If a temporary release execution-map doc is active for the current effort, keep it updated in the same change when scope/sequence decisions change.
+10. If the Swift facade or bridge changed, strict Swift tests, Release library evolution, the public API baseline, semantic parity, and XCFramework checks pass.
 
 ## Quality Gate Contract
 
@@ -243,3 +252,5 @@ Stop and ask before continuing when:
 - Security policy: `SECURITY.md`
 - Public launch checklist: `docs/PUBLIC_LAUNCH_CHECKLIST.md`
 - Maven Central publishing guide: `docs/MAVEN_CENTRAL.md`
+- Swift package guide: `swift/README.md`
+- Swift compatibility contract: `swift/API_PARITY.md`

--- a/docs/ai/WORKFLOWS.md
+++ b/docs/ai/WORKFLOWS.md
@@ -127,5 +127,6 @@ bash tools/agent/check-published-consumer-smoke.sh
 
 On a workstation without a release signing key, use the credential-free Maven Local preflight documented in `docs/MAVEN_CENTRAL.md`; the approval-gated live workflow must still sign every publication.
 
-4. For a live release, use `.github/workflows/publish.yml` via `workflow_dispatch`. Its Central job has read-only repository access and no persisted Git credentials; only the post-publication GitHub Release job receives `contents:write`.
-5. After the release effort is complete, delete the temporary release execution-map doc in the cleanup PR.
+4. For a live release, complete the physical-iPhone qualification, retain its HTTPS evidence URL for the exact source commit, and use `.github/workflows/publish.yml` via `workflow_dispatch` with both qualification inputs. Its Central job has read-only repository access and no persisted Git credentials; only the post-publication GitHub Release job receives `contents:write` to create or reconcile the detached checksum-pinned Swift package manifest commit, coordinated tag/release, and exact Swift assets after Central succeeds.
+5. If Central succeeds but GitHub finalization fails, use `finalize-release` with the exact version and original workflow run ID. This recovery restores the retained immutable inputs and never republishes Maven artifacts.
+6. After the release effort is complete, delete the temporary release execution-map doc in the cleanup PR.

--- a/docs/dependency-decisions.md
+++ b/docs/dependency-decisions.md
@@ -1,5 +1,18 @@
 # Dependency Decisions
 
+## Native Swift PRF Crypto Boundary
+
+The native Swift package keeps WebAuthn option/response handling and platform ceremonies in the shared
+Kotlin implementation, but derives and contains its PRF session key with CryptoKit. The published iOS
+provider used by `webauthn-client-prf-crypto` currently embeds an AES object with an iOS 18.5 deployment
+minimum; statically linking it would make the complete Swift package incompatible with its documented
+iOS 16 baseline.
+
+This is a deliberately narrow platform fallback: HKDF-SHA-256 key derivation, SHA-256 key fingerprinting,
+and AES-256-GCM session operations only. A checked-in derivation vector is asserted by Kotlin tests, Swift
+tests, and the semantic parity checker. Revisit the fallback if the provider can be linked without raising
+the Swift package deployment target.
+
 ## Current State
 
 `webauthn-server-jvm-crypto` is Signum-first:

--- a/documentation/example-inventory.md
+++ b/documentation/example-inventory.md
@@ -4,7 +4,7 @@
 This inventory is generated from the inline `doc-example` directives. It records every user-facing fenced
 example, its single source of truth, and its strongest automated or illustrative verification level.
 
-Managed blocks: **140**
+Managed blocks: **141**
 
 | ID | File | Purpose | Language | Audience | Owner | Source of truth | Verification | Exception |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -65,7 +65,8 @@ Managed blocks: **140**
 | docs-client-first-execution-bash-1 | docs/CLIENT_FIRST_EXECUTION.md:94 | Local Backend App (`sample/backend-ktor`) | bash | consumer | markdown | Markdown block | syntax |  |
 | docs-client-first-execution-bash-2 | docs/CLIENT_FIRST_EXECUTION.md:101 | Local Backend App (`sample/backend-ktor`) | bash | consumer | markdown | Markdown block | syntax |  |
 | docs-client-first-execution-kotlin-2 | docs/CLIENT_FIRST_EXECUTION.md:173 | `webauthn-client-json-core` (optional) | kotlin | consumer | source | documentation/examples/src/androidMain/kotlin/dev/webauthn/documentation/examples/AndroidJsonClientExample.kt#android-json-client | platform-compile |  |
-| docs-maven-central-bash-1 | docs/MAVEN_CENTRAL.md:71 | Local Validation | bash | contributor | markdown | Markdown block | syntax |  |
+| docs-maven-central-bash-1 | docs/MAVEN_CENTRAL.md:74 | Local Validation | bash | contributor | markdown | Markdown block | syntax |  |
+| docs-maven-central-bash-2 | docs/MAVEN_CENTRAL.md:113 | Swift Artifact Dry Run | bash | maintainer | markdown | Markdown block | syntax |  |
 | docs-ai-workflows-bash-1 | docs/ai/WORKFLOWS.md:10 | Standard Change Workflow | bash | contributor | markdown | Markdown block | syntax |  |
 | docs-ai-workflows-bash-2 | docs/ai/WORKFLOWS.md:17 | Standard Change Workflow | bash | contributor | markdown | Markdown block | syntax |  |
 | docs-ai-workflows-bash-3 | docs/ai/WORKFLOWS.md:24 | Standard Change Workflow | bash | contributor | markdown | Markdown block | syntax |  |

--- a/tools/agent/check-published-consumer-smoke.sh
+++ b/tools/agent/check-published-consumer-smoke.sh
@@ -6,13 +6,13 @@ cd "$ROOT_DIR"
 
 KTOR_VERSION="$(sed -n 's/^ktor = \"\(.*\)\"/\1/p' gradle/libs.versions.toml | head -n 1)"
 
-VERSION_NAME="$(sed -n 's/^VERSION_NAME=//p' gradle.properties | head -n 1)"
+VERSION_NAME="${VERSION_NAME_OVERRIDE:-$(sed -n 's/^VERSION_NAME=//p' gradle.properties | head -n 1)}"
 KOTLIN_VERSION="$(sed -n 's/^kotlin = "\(.*\)"/\1/p' gradle/libs.versions.toml | head -n 1)"
 COROUTINES_VERSION="$(sed -n 's/^coroutines = "\(.*\)"/\1/p' gradle/libs.versions.toml | head -n 1)"
 AGP_VERSION="$(sed -n 's/^agp = "\(.*\)"/\1/p' gradle/libs.versions.toml | head -n 1)"
 
 if [[ -z "$VERSION_NAME" ]]; then
-  echo "Unable to resolve VERSION_NAME from gradle.properties" >&2
+  echo "Unable to resolve VERSION_NAME" >&2
   exit 1
 fi
 

--- a/tools/swift/check-release-consumer.sh
+++ b/tools/swift/check-release-consumer.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <released-version>" >&2
+  exit 2
+fi
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "The external Swift release smoke check requires macOS." >&2
+  exit 1
+fi
+
+version="$1"
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+  echo "Invalid released version: $version" >&2
+  exit 1
+fi
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+expected_xcode_version="${WEBAUTHN_EXPECTED_XCODE_VERSION:-26.6}"
+actual_xcode_version="$(xcodebuild -version | awk 'NR == 1 { print $2 }')"
+if [[ "$actual_xcode_version" != "$expected_xcode_version" ]]; then
+  echo "Expected Xcode $expected_xcode_version, found $actual_xcode_version." >&2
+  exit 1
+fi
+
+temporary="$(mktemp -d "${TMPDIR:-/tmp}/webauthn-swift-consumer.XXXXXX")"
+trap 'rm -rf "$temporary"' EXIT
+mkdir -p "$temporary/Sources"
+cat > "$temporary/project.yml" <<EOF
+name: SwiftReleaseConsumer
+options:
+  deploymentTarget:
+    iOS: "16.0"
+packages:
+  WebAuthn:
+    url: https://github.com/szijpeter/webauthn-kotlin-multiplatform.git
+    exactVersion: "$version"
+targets:
+  SwiftReleaseConsumer:
+    type: framework
+    platform: iOS
+    sources: [Sources]
+    dependencies:
+      - package: WebAuthn
+        product: WebAuthn
+    settings:
+      base:
+        SWIFT_VERSION: "6.0"
+        CODE_SIGNING_ALLOWED: NO
+EOF
+cat > "$temporary/Sources/Consumer.swift" <<'EOF'
+import WebAuthn
+
+@MainActor
+public func makePasskeyClient() -> PasskeyClient {
+    PasskeyClient(presentationAnchorProvider: { nil })
+}
+EOF
+
+expected_xcodegen_version="$(tr -d '[:space:]' < "$repo_root/sample/swift-passkey/.xcodegen-version")"
+actual_xcodegen_version="$(xcodegen --version | awk '{ print $2 }')"
+if [[ "$actual_xcodegen_version" != "$expected_xcodegen_version" ]]; then
+  echo "Expected XcodeGen $expected_xcodegen_version, found $actual_xcodegen_version." >&2
+  exit 1
+fi
+xcodegen generate --spec "$temporary/project.yml" --project "$temporary" --quiet
+xcodebuild \
+  -quiet \
+  -project "$temporary/SwiftReleaseConsumer.xcodeproj" \
+  -scheme SwiftReleaseConsumer \
+  -destination 'generic/platform=iOS Simulator' \
+  -derivedDataPath "$temporary/DerivedData" \
+  ARCHS=arm64 \
+  VALID_ARCHS=arm64 \
+  EXCLUDED_ARCHS=x86_64 \
+  CODE_SIGNING_ALLOWED=NO \
+  SWIFT_TREAT_WARNINGS_AS_ERRORS=YES \
+  build
+
+echo "Clean external iOS consumer resolved and compiled WebAuthn $version."

--- a/tools/swift/ci-check.sh
+++ b/tools/swift/ci-check.sh
@@ -26,8 +26,17 @@ fi
 "$repo_root/tools/swift/check-xcframework.sh"
 "$repo_root/tools/swift/check-xcodegen.sh"
 python3 "$repo_root/tools/swift/test_check_parity.py"
+python3 "$repo_root/tools/swift/test_reconcile_release.py"
 "$repo_root/tools/swift/check-parity.py"
 (cd "$repo_root" && swift package dump-package >/dev/null)
+release_manifest_root="$temporary/ReleaseManifest"
+mkdir -p "$release_manifest_root"
+"$repo_root/tools/swift/render-release-package.sh" \
+  "0.0.0" \
+  "0000000000000000000000000000000000000000000000000000000000000000" \
+  "$release_manifest_root/Package.swift"
+ln -s "$repo_root/swift" "$release_manifest_root/swift"
+(cd "$release_manifest_root" && swift package dump-package >/dev/null)
 
 simulator_id="$(xcrun simctl list devices available -j | python3 -c '
 import json, sys

--- a/tools/swift/prepare-release.sh
+++ b/tools/swift/prepare-release.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <version> <output-directory>" >&2
+  exit 2
+fi
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "Swift release artifacts must be prepared on macOS." >&2
+  exit 1
+fi
+
+version="$1"
+output_dir="$2"
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+source_xcframework="$repo_root/client/webauthn-client-swift-bridge/build/XCFrameworks/release/WebAuthnBridge.xcframework"
+temporary="$(mktemp -d "${TMPDIR:-/tmp}/webauthn-swift-release.XXXXXX")"
+trap 'rm -rf "$temporary"' EXIT
+
+"$repo_root/gradlew" -p "$repo_root" \
+  :client:webauthn-client-swift-bridge:assembleWebAuthnBridgeReleaseXCFramework \
+  -PVERSION_NAME="$version" \
+  --stacktrace
+"$repo_root/tools/swift/check-xcframework.sh" "$source_xcframework"
+
+mkdir -p "$output_dir"
+artifact="$temporary/WebAuthnBridge.xcframework"
+ditto --norsrc --noextattr --noqtn --noacl "$source_xcframework" "$artifact"
+find "$artifact" -type f -name '*.swiftsourceinfo' -delete
+for binary in "$artifact"/*/WebAuthnBridge.framework/WebAuthnBridge; do
+  xcrun strip -S "$binary"
+done
+"$repo_root/tools/swift/check-xcframework.sh" "$artifact"
+
+archive="$output_dir/WebAuthnBridge.xcframework.zip"
+ditto --norsrc --noextattr --noqtn --noacl -c -k --keepParent "$artifact" "$archive"
+if unzip -Z1 "$archive" | grep -E '(^|/)(__MACOSX|\.DS_Store|\._)' >/dev/null; then
+  echo "Release archive contains macOS metadata sidecars." >&2
+  exit 1
+fi
+checksum="$(swift package compute-checksum "$archive")"
+printf '%s\n' "$checksum" > "$output_dir/WebAuthnBridge.xcframework.zip.sha256"
+"$repo_root/tools/swift/render-release-package.sh" \
+  "$version" \
+  "$checksum" \
+  "$output_dir/Package.swift"
+manifest_validation_root="$temporary/ManifestValidation"
+mkdir -p "$manifest_validation_root"
+cp "$output_dir/Package.swift" "$manifest_validation_root/Package.swift"
+ln -s "$repo_root/swift" "$manifest_validation_root/swift"
+(cd "$manifest_validation_root" && swift package dump-package >/dev/null)
+
+echo "Prepared Swift release artifact and manifest for v$version."

--- a/tools/swift/reconcile_release.py
+++ b/tools/swift/reconcile_release.py
@@ -1,0 +1,528 @@
+#!/usr/bin/env python3
+"""Validate and reconcile one coordinated Swift GitHub release.
+
+The planning functions are deliberately independent from GitHub so failure and
+recovery states can be tested without publishing anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import dataclasses
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+from typing import Any
+from urllib.parse import urlsplit
+
+
+ARCHIVE_NAME = "WebAuthnBridge.xcframework.zip"
+CHECKSUM_NAME = f"{ARCHIVE_NAME}.sha256"
+PACKAGE_NAME = "Package.swift"
+NOTES_NAME = "release-notes.md"
+METADATA_NAME = "release-metadata.json"
+EXPECTED_ASSET_NAMES = (ARCHIVE_NAME, CHECKSUM_NAME)
+VERSION_PATTERN = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[.-][0-9A-Za-z.-]+)?$")
+COMMIT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+CHECKSUM_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+
+class ReleaseConflict(RuntimeError):
+    """Existing remote state conflicts with the requested release."""
+
+
+@dataclasses.dataclass(frozen=True)
+class ExpectedRelease:
+    version: str
+    tag: str
+    source_commit: str
+    package_sha256: str
+    name: str
+    body: str
+    asset_sha256: dict[str, str]
+    release_dir: Path
+
+
+@dataclasses.dataclass(frozen=True)
+class ReleaseSnapshot:
+    release_id: int
+    tag: str
+    target_commit: str
+    name: str
+    body: str
+    is_draft: bool
+    is_prerelease: bool
+    asset_sha256: dict[str, str]
+
+
+@dataclasses.dataclass(frozen=True)
+class RepositorySnapshot:
+    tag_commit: str | None = None
+    tag_parent: str | None = None
+    tag_changed_files: tuple[str, ...] = ()
+    tag_package_sha256: str | None = None
+    release: ReleaseSnapshot | None = None
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_expected(release_dir: Path) -> ExpectedRelease:
+    required = {
+        ARCHIVE_NAME,
+        CHECKSUM_NAME,
+        PACKAGE_NAME,
+        NOTES_NAME,
+        METADATA_NAME,
+    }
+    missing = sorted(name for name in required if not (release_dir / name).is_file())
+    if missing:
+        raise ReleaseConflict(f"Release inputs are missing: {', '.join(missing)}")
+
+    try:
+        metadata = json.loads((release_dir / METADATA_NAME).read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as error:
+        raise ReleaseConflict(f"Invalid {METADATA_NAME}: {error}") from error
+    if metadata.get("schemaVersion") != 1:
+        raise ReleaseConflict("Release metadata must use schemaVersion 1.")
+    version = metadata.get("version")
+    source_commit = metadata.get("sourceCommit")
+    if not isinstance(version, str) or not VERSION_PATTERN.fullmatch(version):
+        raise ReleaseConflict("Release metadata contains an invalid version.")
+    if not isinstance(source_commit, str) or not COMMIT_PATTERN.fullmatch(source_commit):
+        raise ReleaseConflict("Release metadata contains an invalid source commit.")
+    if metadata.get("physicalDeviceQualified") is not True:
+        raise ReleaseConflict("Swift release metadata lacks physical-device qualification.")
+    qualification_evidence = metadata.get("qualificationEvidence")
+    evidence_url = urlsplit(qualification_evidence) if isinstance(qualification_evidence, str) else None
+    if (
+        not isinstance(qualification_evidence, str)
+        or evidence_url is None
+        or evidence_url.scheme != "https"
+        or not evidence_url.netloc
+        or qualification_evidence.strip() != qualification_evidence
+        or any(character.isspace() for character in qualification_evidence)
+    ):
+        raise ReleaseConflict(
+            "Swift release metadata lacks a valid HTTPS physical-device qualification evidence URL."
+        )
+
+    checksum_text = (release_dir / CHECKSUM_NAME).read_text(encoding="utf-8")
+    checksum = checksum_text.removesuffix("\n")
+    if checksum_text != f"{checksum}\n" or not CHECKSUM_PATTERN.fullmatch(checksum):
+        raise ReleaseConflict(f"{CHECKSUM_NAME} must contain one lowercase SHA-256 value.")
+    archive_path = release_dir / ARCHIVE_NAME
+    if sha256_file(archive_path) != checksum:
+        raise ReleaseConflict("Swift release archive does not match its checksum file.")
+
+    package_bytes = (release_dir / PACKAGE_NAME).read_bytes()
+    package_text = package_bytes.decode("utf-8")
+    expected_url = (
+        "https://github.com/szijpeter/webauthn-kotlin-multiplatform/"
+        f"releases/download/v{version}/{ARCHIVE_NAME}"
+    )
+    required_manifest_fragments = (
+        "// swift-tools-version: 6.0",
+        f'url: "{expected_url}"',
+        f'checksum: "{checksum}"',
+        "swiftLanguageModes: [.v6]",
+    )
+    if any(fragment not in package_text for fragment in required_manifest_fragments):
+        raise ReleaseConflict("Generated Package.swift does not match the release inputs.")
+
+    notes = (release_dir / NOTES_NAME).read_text(encoding="utf-8")
+    if not notes.strip():
+        raise ReleaseConflict("Curated release notes must not be empty.")
+
+    return ExpectedRelease(
+        version=version,
+        tag=f"v{version}",
+        source_commit=source_commit,
+        package_sha256=sha256_bytes(package_bytes),
+        name=f"v{version}",
+        body=notes,
+        asset_sha256={
+            ARCHIVE_NAME: sha256_file(archive_path),
+            CHECKSUM_NAME: sha256_file(release_dir / CHECKSUM_NAME),
+        },
+        release_dir=release_dir,
+    )
+
+
+def _validate_tag(snapshot: RepositorySnapshot, expected: ExpectedRelease) -> None:
+    if snapshot.tag_parent != expected.source_commit:
+        raise ReleaseConflict("Existing release tag is not parented to the expected source commit.")
+    if snapshot.tag_changed_files != (PACKAGE_NAME,):
+        raise ReleaseConflict("Existing release tag must change only Package.swift.")
+    if snapshot.tag_package_sha256 != expected.package_sha256:
+        raise ReleaseConflict("Existing release tag contains a different Package.swift.")
+
+
+def _validate_release_metadata(
+    release: ReleaseSnapshot,
+    expected: ExpectedRelease,
+    _tag_commit: str,
+) -> None:
+    if release.tag != expected.tag:
+        raise ReleaseConflict("Existing release has a different tag.")
+    if release.name != expected.name or release.body != expected.body:
+        raise ReleaseConflict("Existing release title or notes differ from curated inputs.")
+    if release.is_prerelease:
+        raise ReleaseConflict("Existing release is unexpectedly marked as a prerelease.")
+
+
+def plan_reconciliation(snapshot: RepositorySnapshot, expected: ExpectedRelease) -> tuple[str, ...]:
+    """Return the safe actions needed, rejecting every conflicting state."""
+    if snapshot.tag_commit is None:
+        if snapshot.release is not None:
+            raise ReleaseConflict("A release exists without a resolvable release tag.")
+        return (
+            "create-release-commit-and-tag",
+            "create-draft-release",
+            *(f"upload:{name}" for name in EXPECTED_ASSET_NAMES),
+            "publish-release",
+        )
+
+    _validate_tag(snapshot, expected)
+    if snapshot.release is None:
+        return (
+            "create-draft-release",
+            *(f"upload:{name}" for name in EXPECTED_ASSET_NAMES),
+            "publish-release",
+        )
+
+    release = snapshot.release
+    _validate_release_metadata(release, expected, snapshot.tag_commit)
+    unexpected_assets = sorted(set(release.asset_sha256) - set(EXPECTED_ASSET_NAMES))
+    if unexpected_assets:
+        raise ReleaseConflict(
+            f"Existing release has unexpected assets: {', '.join(unexpected_assets)}"
+        )
+    mismatched_assets = [
+        name
+        for name in EXPECTED_ASSET_NAMES
+        if name in release.asset_sha256
+        and release.asset_sha256[name] != expected.asset_sha256[name]
+    ]
+    if mismatched_assets:
+        raise ReleaseConflict(
+            f"Existing release has mismatched assets: {', '.join(mismatched_assets)}"
+        )
+    actions = [
+        f"upload:{name}"
+        for name in EXPECTED_ASSET_NAMES
+        if name not in release.asset_sha256
+    ]
+    if release.is_draft:
+        actions.append("publish-release")
+    return tuple(actions)
+
+
+class GitHubClient:
+    def __init__(self, repository: str, executable: str = "gh") -> None:
+        if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
+            raise ReleaseConflict("GITHUB_REPOSITORY must be an owner/repository pair.")
+        self.repository = repository
+        self.executable = executable
+
+    def _run(
+        self,
+        arguments: list[str],
+        *,
+        input_bytes: bytes | None = None,
+        allow_not_found: bool = False,
+    ) -> bytes | None:
+        completed = subprocess.run(
+            [self.executable, *arguments],
+            input=input_bytes,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if completed.returncode == 0:
+            return completed.stdout
+        stderr = completed.stderr.decode("utf-8", errors="replace")
+        if allow_not_found and ("HTTP 404" in stderr or "Not Found" in stderr):
+            return None
+        raise ReleaseConflict(f"GitHub CLI failed: {stderr.strip()}")
+
+    def api_json(
+        self,
+        endpoint: str,
+        *,
+        method: str = "GET",
+        body: dict[str, Any] | None = None,
+        allow_not_found: bool = False,
+    ) -> dict[str, Any] | None:
+        arguments = ["api", "--method", method, endpoint]
+        input_bytes = None
+        if body is not None:
+            arguments += ["--input", "-"]
+            input_bytes = json.dumps(body, separators=(",", ":")).encode("utf-8")
+        output = self._run(
+            arguments,
+            input_bytes=input_bytes,
+            allow_not_found=allow_not_found,
+        )
+        if output is None:
+            return None
+        try:
+            value = json.loads(output)
+        except json.JSONDecodeError as error:
+            raise ReleaseConflict(f"GitHub returned invalid JSON for {endpoint}.") from error
+        if not isinstance(value, dict):
+            raise ReleaseConflict(f"GitHub returned an unexpected payload for {endpoint}.")
+        return value
+
+    def asset_bytes(self, asset_id: int) -> bytes:
+        output = self._run(
+            [
+                "api",
+                "-H",
+                "Accept: application/octet-stream",
+                f"repos/{self.repository}/releases/assets/{asset_id}",
+            ]
+        )
+        assert output is not None
+        return output
+
+    def upload_asset(self, tag: str, path: Path) -> None:
+        self._run(
+            [
+                "release",
+                "upload",
+                tag,
+                str(path),
+                "--repo",
+                self.repository,
+            ]
+        )
+
+
+def collect_snapshot(client: GitHubClient, expected: ExpectedRelease) -> RepositorySnapshot:
+    commit = client.api_json(
+        f"repos/{client.repository}/commits/{expected.tag}",
+        allow_not_found=True,
+    )
+    tag_commit: str | None = None
+    tag_parent: str | None = None
+    changed_files: tuple[str, ...] = ()
+    package_digest: str | None = None
+    if commit is not None:
+        tag_commit = str(commit.get("sha", ""))
+        git_commit = client.api_json(f"repos/{client.repository}/git/commits/{tag_commit}")
+        assert git_commit is not None
+        parents = git_commit.get("parents", [])
+        if len(parents) != 1:
+            raise ReleaseConflict("Release commit must have exactly one parent.")
+        tag_parent = str(parents[0].get("sha", ""))
+        comparison = client.api_json(
+            f"repos/{client.repository}/compare/{expected.source_commit}...{tag_commit}"
+        )
+        assert comparison is not None
+        if comparison.get("ahead_by") != 1 or comparison.get("total_commits") != 1:
+            raise ReleaseConflict("Release tag must be exactly one commit ahead of its source.")
+        changed_files = tuple(sorted(str(item.get("filename", "")) for item in comparison.get("files", [])))
+        content = client.api_json(
+            f"repos/{client.repository}/contents/{PACKAGE_NAME}?ref={expected.tag}"
+        )
+        assert content is not None
+        try:
+            package_bytes = base64.b64decode(str(content["content"]), validate=False)
+        except (KeyError, ValueError) as error:
+            raise ReleaseConflict("Unable to decode tagged Package.swift.") from error
+        package_digest = sha256_bytes(package_bytes)
+
+    release_json = client.api_json(
+        f"repos/{client.repository}/releases/tags/{expected.tag}",
+        allow_not_found=True,
+    )
+    release_snapshot: ReleaseSnapshot | None = None
+    if release_json is not None:
+        assets: dict[str, str] = {}
+        for item in release_json.get("assets", []):
+            name = str(item.get("name", ""))
+            if name in assets:
+                raise ReleaseConflict(f"Release contains duplicate asset name: {name}")
+            assets[name] = sha256_bytes(client.asset_bytes(int(item["id"])))
+        release_snapshot = ReleaseSnapshot(
+            release_id=int(release_json["id"]),
+            tag=str(release_json.get("tag_name", "")),
+            target_commit=str(release_json.get("target_commitish", "")),
+            name=str(release_json.get("name", "")),
+            body=str(release_json.get("body", "")),
+            is_draft=bool(release_json.get("draft")),
+            is_prerelease=bool(release_json.get("prerelease")),
+            asset_sha256=assets,
+        )
+    return RepositorySnapshot(
+        tag_commit=tag_commit,
+        tag_parent=tag_parent,
+        tag_changed_files=changed_files,
+        tag_package_sha256=package_digest,
+        release=release_snapshot,
+    )
+
+
+def create_release_commit_and_tag(client: GitHubClient, expected: ExpectedRelease) -> None:
+    source = client.api_json(
+        f"repos/{client.repository}/git/commits/{expected.source_commit}"
+    )
+    assert source is not None
+    package_content = base64.b64encode(
+        (expected.release_dir / PACKAGE_NAME).read_bytes()
+    ).decode("ascii")
+    blob = client.api_json(
+        f"repos/{client.repository}/git/blobs",
+        method="POST",
+        body={"content": package_content, "encoding": "base64"},
+    )
+    assert blob is not None
+    tree = client.api_json(
+        f"repos/{client.repository}/git/trees",
+        method="POST",
+        body={
+            "base_tree": source["tree"]["sha"],
+            "tree": [
+                {
+                    "path": PACKAGE_NAME,
+                    "mode": "100644",
+                    "type": "blob",
+                    "sha": blob["sha"],
+                }
+            ],
+        },
+    )
+    assert tree is not None
+    commit = client.api_json(
+        f"repos/{client.repository}/git/commits",
+        method="POST",
+        body={
+            "message": f"release: prepare Swift package {expected.tag}",
+            "tree": tree["sha"],
+            "parents": [expected.source_commit],
+        },
+    )
+    assert commit is not None
+    client.api_json(
+        f"repos/{client.repository}/git/refs",
+        method="POST",
+        body={"ref": f"refs/tags/{expected.tag}", "sha": commit["sha"]},
+    )
+
+
+def create_draft_release(
+    client: GitHubClient,
+    expected: ExpectedRelease,
+    tag_commit: str,
+) -> None:
+    client.api_json(
+        f"repos/{client.repository}/releases",
+        method="POST",
+        body={
+            "tag_name": expected.tag,
+            "target_commitish": tag_commit,
+            "name": expected.name,
+            "body": expected.body,
+            "draft": True,
+            "prerelease": False,
+        },
+    )
+
+
+def reconcile(client: GitHubClient, expected: ExpectedRelease) -> None:
+    snapshot = collect_snapshot(client, expected)
+    actions = plan_reconciliation(snapshot, expected)
+    if "create-release-commit-and-tag" in actions:
+        create_release_commit_and_tag(client, expected)
+        snapshot = collect_snapshot(client, expected)
+        _validate_tag(snapshot, expected)
+    assert snapshot.tag_commit is not None
+
+    if "create-draft-release" in actions:
+        create_draft_release(client, expected, snapshot.tag_commit)
+        snapshot = collect_snapshot(client, expected)
+    if snapshot.release is None:
+        raise ReleaseConflict("GitHub release creation did not produce a readable draft.")
+    _validate_release_metadata(snapshot.release, expected, snapshot.tag_commit)
+
+    actions = plan_reconciliation(snapshot, expected)
+    for action in actions:
+        if action.startswith("upload:"):
+            name = action.split(":", 1)[1]
+            client.upload_asset(expected.tag, expected.release_dir / name)
+
+    snapshot = collect_snapshot(client, expected)
+    actions = plan_reconciliation(snapshot, expected)
+    remaining_uploads = [action for action in actions if action.startswith("upload:")]
+    if remaining_uploads:
+        raise ReleaseConflict("Release asset read-back did not match the prepared inputs.")
+    if "publish-release" in actions:
+        assert snapshot.release is not None
+        client.api_json(
+            f"repos/{client.repository}/releases/{snapshot.release.release_id}",
+            method="PATCH",
+            body={"draft": False},
+        )
+
+    final_snapshot = collect_snapshot(client, expected)
+    final_actions = plan_reconciliation(final_snapshot, expected)
+    if final_actions:
+        raise ReleaseConflict(
+            f"Release read-back is incomplete: {', '.join(final_actions)}"
+        )
+    print(
+        f"Verified {expected.tag}: exact tag manifest, release metadata, and assets."
+    )
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("release_dir", type=Path)
+    parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY"))
+    parser.add_argument("--gh", default=os.environ.get("GH_BIN", "gh"))
+    parser.add_argument("--validate-only", action="store_true")
+    parser.add_argument("--require-empty", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    arguments = parse_arguments()
+    try:
+        expected = load_expected(arguments.release_dir.resolve())
+        if arguments.validate_only:
+            print(f"Validated Swift release inputs for {expected.tag}.")
+            return 0
+        if not arguments.repository:
+            raise ReleaseConflict("GITHUB_REPOSITORY is required for reconciliation.")
+        client = GitHubClient(arguments.repository, arguments.gh)
+        if arguments.require_empty:
+            snapshot = collect_snapshot(client, expected)
+            if snapshot.tag_commit is not None or snapshot.release is not None:
+                raise ReleaseConflict(
+                    "Release state already exists; use finalize-release with the original workflow artifact."
+                )
+            print(f"Verified that {expected.tag} has no existing tag or release.")
+            return 0
+        reconcile(client, expected)
+        return 0
+    except ReleaseConflict as error:
+        print(f"Swift release reconciliation failed: {error}", file=os.sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/swift/render-release-package.sh
+++ b/tools/swift/render-release-package.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "Usage: $0 <version> <checksum> <output-file>" >&2
+  exit 2
+fi
+
+version="$1"
+checksum="$2"
+output="$3"
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+  echo "Invalid Swift package version: $version" >&2
+  exit 1
+fi
+if [[ ! "$checksum" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "Invalid Swift package checksum." >&2
+  exit 1
+fi
+
+cat > "$output" <<EOF
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "WebAuthn",
+    platforms: [
+        .iOS(.v16),
+    ],
+    products: [
+        .library(name: "WebAuthn", targets: ["WebAuthn"]),
+    ],
+    targets: [
+        .binaryTarget(
+            name: "WebAuthnBridge",
+            url: "https://github.com/szijpeter/webauthn-kotlin-multiplatform/releases/download/v${version}/WebAuthnBridge.xcframework.zip",
+            checksum: "${checksum}"
+        ),
+        .target(
+            name: "WebAuthn",
+            dependencies: ["WebAuthnBridge"],
+            path: "swift/Sources/WebAuthn"
+        ),
+        .testTarget(
+            name: "WebAuthnTests",
+            dependencies: ["WebAuthn"],
+            path: "swift/Tests/WebAuthnTests"
+        ),
+    ],
+    swiftLanguageModes: [.v6]
+)
+EOF

--- a/tools/swift/test_reconcile_release.py
+++ b/tools/swift/test_reconcile_release.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from reconcile_release import (
+    ARCHIVE_NAME,
+    CHECKSUM_NAME,
+    ExpectedRelease,
+    ReleaseConflict,
+    ReleaseSnapshot,
+    RepositorySnapshot,
+    load_expected,
+    plan_reconciliation,
+)
+
+
+SOURCE_COMMIT = "1" * 40
+TAG_COMMIT = "2" * 40
+
+
+def digest(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+class ReconcileReleaseTests(unittest.TestCase):
+    def create_expected(
+        self,
+        root: Path,
+        *,
+        physical_device_qualified: bool = True,
+        qualification_evidence: str = "https://github.com/example/repository/issues/123",
+    ) -> ExpectedRelease:
+        archive = b"reviewed-xcframework"
+        checksum = digest(archive)
+        (root / ARCHIVE_NAME).write_bytes(archive)
+        (root / CHECKSUM_NAME).write_text(f"{checksum}\n", encoding="utf-8")
+        (root / "Package.swift").write_text(
+            "// swift-tools-version: 6.0\n"
+            "import PackageDescription\n"
+            "let packageURL = (\n"
+            "    url: \"https://github.com/szijpeter/webauthn-kotlin-multiplatform/"
+            f"releases/download/v1.2.3/{ARCHIVE_NAME}\",\n"
+            f"    checksum: \"{checksum}\"\n"
+            ")\n"
+            "// swiftLanguageModes: [.v6]\n",
+            encoding="utf-8",
+        )
+        (root / "release-notes.md").write_text("Reviewed notes.\n", encoding="utf-8")
+        (root / "release-metadata.json").write_text(
+            json.dumps(
+                {
+                    "schemaVersion": 1,
+                    "version": "1.2.3",
+                    "sourceCommit": SOURCE_COMMIT,
+                    "physicalDeviceQualified": physical_device_qualified,
+                    "qualificationEvidence": qualification_evidence,
+                }
+            ),
+            encoding="utf-8",
+        )
+        return load_expected(root)
+
+    def test_physical_device_qualification_is_required(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(ReleaseConflict, "physical-device qualification"):
+                self.create_expected(
+                    Path(directory),
+                    physical_device_qualified=False,
+                )
+
+    def test_physical_device_qualification_evidence_is_required(self) -> None:
+        for evidence in (
+            "",
+            "https://",
+            "http://example.invalid/evidence",
+            "https://example.invalid/bad evidence",
+        ):
+            with self.subTest(evidence=evidence), tempfile.TemporaryDirectory() as directory:
+                with self.assertRaisesRegex(ReleaseConflict, "qualification evidence URL"):
+                    self.create_expected(
+                        Path(directory),
+                        qualification_evidence=evidence,
+                    )
+
+    def matching_tag(self, expected: ExpectedRelease) -> RepositorySnapshot:
+        return RepositorySnapshot(
+            tag_commit=TAG_COMMIT,
+            tag_parent=SOURCE_COMMIT,
+            tag_changed_files=("Package.swift",),
+            tag_package_sha256=expected.package_sha256,
+        )
+
+    def test_no_release_plans_full_creation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            expected = self.create_expected(Path(directory))
+            self.assertEqual(
+                plan_reconciliation(RepositorySnapshot(), expected),
+                (
+                    "create-release-commit-and-tag",
+                    "create-draft-release",
+                    f"upload:{ARCHIVE_NAME}",
+                    f"upload:{CHECKSUM_NAME}",
+                    "publish-release",
+                ),
+            )
+
+    def test_matching_partial_release_repairs_only_missing_asset(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            expected = self.create_expected(Path(directory))
+            tag = self.matching_tag(expected)
+            snapshot = RepositorySnapshot(
+                **{field: getattr(tag, field) for field in (
+                    "tag_commit",
+                    "tag_parent",
+                    "tag_changed_files",
+                    "tag_package_sha256",
+                )},
+                release=ReleaseSnapshot(
+                    release_id=7,
+                    tag=expected.tag,
+                    target_commit=TAG_COMMIT,
+                    name=expected.name,
+                    body=expected.body,
+                    is_draft=True,
+                    is_prerelease=False,
+                    asset_sha256={ARCHIVE_NAME: expected.asset_sha256[ARCHIVE_NAME]},
+                ),
+            )
+            self.assertEqual(
+                plan_reconciliation(snapshot, expected),
+                (f"upload:{CHECKSUM_NAME}", "publish-release"),
+            )
+
+    def test_conflicting_tag_is_rejected_without_actions(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            expected = self.create_expected(Path(directory))
+            snapshot = RepositorySnapshot(
+                tag_commit=TAG_COMMIT,
+                tag_parent="3" * 40,
+                tag_changed_files=("Package.swift",),
+                tag_package_sha256=expected.package_sha256,
+            )
+            with self.assertRaisesRegex(ReleaseConflict, "source commit"):
+                plan_reconciliation(snapshot, expected)
+
+    def test_matching_published_release_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            expected = self.create_expected(Path(directory))
+            tag = self.matching_tag(expected)
+            snapshot = RepositorySnapshot(
+                **{field: getattr(tag, field) for field in (
+                    "tag_commit",
+                    "tag_parent",
+                    "tag_changed_files",
+                    "tag_package_sha256",
+                )},
+                release=ReleaseSnapshot(
+                    release_id=7,
+                    tag=expected.tag,
+                    target_commit=TAG_COMMIT,
+                    name=expected.name,
+                    body=expected.body,
+                    is_draft=False,
+                    is_prerelease=False,
+                    asset_sha256=expected.asset_sha256,
+                ),
+            )
+            self.assertEqual(plan_reconciliation(snapshot, expected), ())
+
+    def test_unexpected_asset_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            expected = self.create_expected(Path(directory))
+            tag = self.matching_tag(expected)
+            snapshot = RepositorySnapshot(
+                **{field: getattr(tag, field) for field in (
+                    "tag_commit",
+                    "tag_parent",
+                    "tag_changed_files",
+                    "tag_package_sha256",
+                )},
+                release=ReleaseSnapshot(
+                    release_id=7,
+                    tag=expected.tag,
+                    target_commit=TAG_COMMIT,
+                    name=expected.name,
+                    body=expected.body,
+                    is_draft=False,
+                    is_prerelease=False,
+                    asset_sha256={"unexpected.txt": digest(b"unexpected")},
+                ),
+            )
+            with self.assertRaisesRegex(ReleaseConflict, "unexpected assets"):
+                plan_reconciliation(snapshot, expected)
+
+    def test_mismatched_expected_asset_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            expected = self.create_expected(Path(directory))
+            tag = self.matching_tag(expected)
+            snapshot = RepositorySnapshot(
+                **{field: getattr(tag, field) for field in (
+                    "tag_commit",
+                    "tag_parent",
+                    "tag_changed_files",
+                    "tag_package_sha256",
+                )},
+                release=ReleaseSnapshot(
+                    release_id=7,
+                    tag=expected.tag,
+                    target_commit=TAG_COMMIT,
+                    name=expected.name,
+                    body=expected.body,
+                    is_draft=True,
+                    is_prerelease=False,
+                    asset_sha256={ARCHIVE_NAME: digest(b"different")},
+                ),
+            )
+            with self.assertRaisesRegex(ReleaseConflict, "mismatched assets"):
+                plan_reconciliation(snapshot, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a blocking macOS CI job for the bridge, Swift facade, semantic parity, sample tests, Release build, and API baselines
- add deterministic XCFramework post-processing, zip integrity checks, SwiftPM checksum generation, and release-manifest validation
- extend tag publishing with read-only preflight checks before Maven Central and a post-publication GitHub release step
- create the release tag from a detached commit containing the checksum-pinned remote Swift package manifest
- enforce least-privilege workflow permissions, no persisted Git credentials, and remote release/tag read-back
- document publishing, security, dependency, and operational release requirements

## Validation

- full `tools/swift/ci-check.sh` passed
- release preparation dry run passed, including archive integrity, checksum, and generated manifest parsing
- `./gradlew publishToMavenLocal --stacktrace` passed (886 tasks)
- workflow YAML and shell/Python syntax checks passed
- strict full-scope repository quality gate passed

No live release or tag was created.

## Stack

- #268
- #269
- #270
- **#271 — PR 4 of 5: this PR**
- #272
